### PR TITLE
More return info on LtiOutcomesHelper methods

### DIFF
--- a/LtiLibrary.Core/Common/BasicResult.cs
+++ b/LtiLibrary.Core/Common/BasicResult.cs
@@ -1,0 +1,23 @@
+﻿namespace LtiLibrary.Core.Common
+{
+    /// <summary>
+    /// A basic result with a boolean success and string message.
+    /// This class can be implicitly cast to a bool.
+    /// </summary>
+    public class BasicResult
+    {   
+        public bool IsValid  { get; set; }
+        public string Message { get; set; }
+
+        public BasicResult(bool isValid = true, string message = "")
+        {
+            IsValid = isValid;
+            Message = message;
+        }
+
+        public static implicit operator bool(BasicResult basicResult)
+        {
+            return basicResult != null && basicResult.IsValid;
+        }
+    }
+}

--- a/LtiLibrary.Core/LtiLibrary.Core.csproj
+++ b/LtiLibrary.Core/LtiLibrary.Core.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\BasicResult.cs" />
     <Compile Include="Common\JsonLdObject.cs" />
     <Compile Include="Common\JsonLdObjectContractResolver.cs" />
     <Compile Include="Common\UriAttribute.cs" />

--- a/LtiLibrary.Core/Outcomes/LisResult.cs
+++ b/LtiLibrary.Core/Outcomes/LisResult.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using LtiLibrary.Core.Common;
 
 namespace LtiLibrary.Core.Outcomes
 {
     [Obsolete("Use LtiLibrary.Core.Outcomes.v1.LisResult")]
-    public class LisResult
+    public class LisResult : BasicResult
     {
-        public bool IsValid { get; set; }
         public double? Score { get; set; }
         public string SourcedId { get; set; }
     }

--- a/LtiLibrary.Core/Outcomes/LtiOutcomesHelper.cs
+++ b/LtiLibrary.Core/Outcomes/LtiOutcomesHelper.cs
@@ -37,7 +37,7 @@ namespace LtiLibrary.Core.Outcomes
                     "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0");
         }
 
-        public static bool DeleteScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
+        public static BasicResult DeleteScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {
@@ -65,13 +65,13 @@ namespace LtiLibrary.Core.Outcomes
                 var webResponse = webRequest.GetResponse() as HttpWebResponse;
                 return ParseDeleteResultResponse(webResponse);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return false;
+                return new BasicResult(false, ex.ToString());
             }
         }
 
-        public static bool PostScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId, double? score)
+        public static BasicResult PostScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId, double? score)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {
@@ -112,9 +112,9 @@ namespace LtiLibrary.Core.Outcomes
                 var webResponse = webRequest.GetResponse() as HttpWebResponse;
                 return ParsePostResultResponse(webResponse);
             }
-            catch
+            catch (Exception ex)
             {
-                return false;
+                return new BasicResult(false, ex.ToString());
             }
         }
 
@@ -155,40 +155,42 @@ namespace LtiLibrary.Core.Outcomes
             return imsxEnvelope != null;
         }
 
-        private static bool ParseDeleteResultResponse(HttpWebResponse webResponse)
+        private static BasicResult ParseDeleteResultResponse(HttpWebResponse webResponse)
         {
-            if (webResponse == null) return false;
+            if (webResponse == null) return new BasicResult(false, "Invalid webResponse");
 
             var stream = webResponse.GetResponseStream();
-            if (stream == null) return false;
+            if (stream == null) return new BasicResult(false, "Invalid stream");
 
             var imsxEnvelope = ImsxResponseSerializer.Deserialize(stream) as imsx_POXEnvelopeType;
-            if (imsxEnvelope == null) return false;
+            if (imsxEnvelope == null) return new BasicResult(false, "Invalid imsxEnvelope");
 
             var imsxHeader = imsxEnvelope.imsx_POXHeader.Item as imsx_ResponseHeaderInfoType;
-            if (imsxHeader == null) return false;
+            if (imsxHeader == null) return new BasicResult(false, "Invalid imsxHeader");
 
             var imsxStatus = imsxHeader.imsx_statusInfo.imsx_codeMajor;
 
-            return imsxStatus == imsx_CodeMajorType.success;
+            return new BasicResult(imsxStatus == imsx_CodeMajorType.success,
+                imsxHeader.imsx_statusInfo.imsx_description);
         }
 
-        private static bool ParsePostResultResponse(HttpWebResponse webResponse)
+        private static BasicResult ParsePostResultResponse(HttpWebResponse webResponse)
         {
-            if (webResponse == null) return false;
+            if (webResponse == null) return new BasicResult(false, "Invalid webResponse");
 
             var stream = webResponse.GetResponseStream();
-            if (stream == null) return false;
+            if (stream == null) return new BasicResult(false, "Invalid stream");
 
             var imsxEnvelope = ImsxResponseSerializer.Deserialize(stream) as imsx_POXEnvelopeType;
-            if (imsxEnvelope == null) return false;
+            if (imsxEnvelope == null) return new BasicResult(false, "Invalid imsxEnvelope");
 
             var imsxHeader = imsxEnvelope.imsx_POXHeader.Item as imsx_ResponseHeaderInfoType;
-            if (imsxHeader == null) return false;
+            if (imsxHeader == null) return new BasicResult(false, "Invalid imsxHeader");
 
             var imsxStatus = imsxHeader.imsx_statusInfo.imsx_codeMajor;
 
-            return imsxStatus == imsx_CodeMajorType.success;
+            return new BasicResult(imsxStatus == imsx_CodeMajorType.success,
+                imsxHeader.imsx_statusInfo.imsx_description);
         }
 
         public static LisResult ReadScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
@@ -219,9 +221,9 @@ namespace LtiLibrary.Core.Outcomes
                 var webResponse = webRequest.GetResponse() as HttpWebResponse;
                 return ParseReadResultResponse(webResponse);
             }
-            catch
+            catch (Exception ex)
             {
-                return new LisResult {IsValid = false};
+                return new LisResult {IsValid = false, Message = ex.ToString()};
             }
         }
 
@@ -229,13 +231,13 @@ namespace LtiLibrary.Core.Outcomes
         {
             if (webResponse == null)
             {
-                return new LisResult { IsValid = false };
+                return new LisResult { IsValid = false, Message = "Invalid webResponse" };
             }
 
             var stream = webResponse.GetResponseStream();
             if (stream == null)
             {
-                return new LisResult { IsValid = false };
+                return new LisResult { IsValid = false, Message = "Invalid stream" };
             }
 
             var imsxEnvelope = (imsx_POXEnvelopeType)ImsxResponseSerializer.Deserialize(stream);
@@ -244,7 +246,7 @@ namespace LtiLibrary.Core.Outcomes
 
             if (imsxStatus != imsx_CodeMajorType.success)
             {
-                return new LisResult { IsValid = false };
+                return new LisResult { IsValid = false, Message = imsxHeader.imsx_statusInfo.imsx_description};
             }
 
             var imsxBody = (readResultResponse) imsxEnvelope.imsx_POXBody.Item;

--- a/LtiLibrary.Core/Outcomes/v1/LisResult.cs
+++ b/LtiLibrary.Core/Outcomes/v1/LisResult.cs
@@ -1,8 +1,9 @@
-﻿namespace LtiLibrary.Core.Outcomes.v1
+﻿using LtiLibrary.Core.Common;
+
+namespace LtiLibrary.Core.Outcomes.v1
 {
-    public class LisResult
+    public class LisResult : BasicResult
     {
-        public bool IsValid { get; set; }
         public double? Score { get; set; }
         public string SourcedId { get; set; }
     }


### PR DESCRIPTION
For one reason or another, we've been running into errors when using the
LtiOutcomesHelper, and it's
difficult to diagnose the problem when the reason is hidden. This should
expose a bit more info on why a false result is being sent back. I added
a new BasicResult class that can be implicitly cast to a bool. The root
and v1 LisResult classes now implement this BaiscResult and use its
IsValid property. For the message, Exceptions return back its ToString
result, and imsx_StatusInfoType will return the imsx_description.
