### PR TITLE
Fixup content item discrepancies

### DIFF
--- a/LtiLibrary.Core.Tests/JsonLdObjectTests.cs
+++ b/LtiLibrary.Core.Tests/JsonLdObjectTests.cs
@@ -23,7 +23,7 @@ namespace LtiLibrary.Core.Tests
                     }
                 }
             };
-            JsonAssertions.AssertSameObjectJson(parent, "ExternalAndInternalContexts");
+            JsonAssertions.AssertSameJsonLdObject( parent, "ExternalAndInternalContexts");
         }
 
         [Fact]
@@ -34,7 +34,18 @@ namespace LtiLibrary.Core.Tests
                 Id = new Uri("http://localhost/test/1"),
                 Name = "MyParent",
             };
-            JsonAssertions.AssertSameObjectJson(parent, "ExternalContextOnly");
+            JsonAssertions.AssertSameJsonLdObject( parent, "ExternalContextOnly");
+        }
+
+        [Fact]
+        public void ExternalContextOnly_ToJsonLdStringMatchesReferenceJson()
+        {
+           var parent = new Parent
+           {
+              Id = new Uri( "http://localhost/test/1" ),
+              Name = "MyParent",
+           };
+           JsonAssertions.AssertSameJsonLdObject( parent, "ExternalContextOnly" );
         }
 
         [Fact]
@@ -48,7 +59,7 @@ namespace LtiLibrary.Core.Tests
                     Name = "MyGrandChild"
                 }
             };
-            JsonAssertions.AssertSameObjectJson(child, "InternalContextOnly");
+            JsonAssertions.AssertSameJsonLdObject( child, "InternalContextOnly");
         }
     }
 

--- a/LtiLibrary.Core.Tests/ReferenceJson/LtiLinkContentItem.json
+++ b/LtiLibrary.Core.Tests/ReferenceJson/LtiLinkContentItem.json
@@ -1,5 +1,5 @@
 ﻿{
-  "@type" : "LtiLink",
+  "@type" : "LtiLinkItem",
   "mediaType" : "application/vnd.ims.lti.v1.ltilink",
   "icon" : {
     "@id" : "https://www.server.com/path/animage.png",

--- a/LtiLibrary.Core.Tests/SimpleHelpers/JsonAssertions.cs
+++ b/LtiLibrary.Core.Tests/SimpleHelpers/JsonAssertions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Diagnostics;
+using LtiLibrary.Core.Common;
+using LtiLibrary.Core.Extensions;
 using LtiLibrary.Core.Tests.TestHelpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -20,7 +22,6 @@ namespace LtiLibrary.Core.Tests.SimpleHelpers
 
             public static void AssertSameObjectJson(object obj, string eventReferenceFile)
             {
-
                 var eventJsonString = JsonConvert.SerializeObject(obj, SerializerSettings);
                 var eventJObject = JObject.Parse(eventJsonString);
                 var refJsonString = TestUtils.LoadReferenceJsonFile(eventReferenceFile);
@@ -33,6 +34,22 @@ namespace LtiLibrary.Core.Tests.SimpleHelpers
 
                 Assert.Null(diff.NewValues);
                 Assert.Null(diff.OldValues);
+            }
+
+            public static void AssertSameJsonLdObject( JsonLdObject obj, string eventReferenceFile )
+            {
+               var eventJsonString = obj.ToJsonLdString();
+               var eventJObject = JObject.Parse( eventJsonString );
+               var refJsonString = TestUtils.LoadReferenceJsonFile( eventReferenceFile );
+               var refJObject = JObject.Parse( refJsonString );
+
+               var diff = ObjectDiffPatch.GenerateDiff( refJObject, eventJObject );
+
+               Trace.WriteLine( diff.NewValues );
+               Trace.WriteLine( diff.OldValues );
+
+               Assert.Null( diff.NewValues );
+               Assert.Null( diff.OldValues );
             }
         }
 }

--- a/LtiLibrary.Core/Common/JsonLdObjectContractResolver.cs
+++ b/LtiLibrary.Core/Common/JsonLdObjectContractResolver.cs
@@ -9,6 +9,18 @@ namespace LtiLibrary.Core.Common
     /// </summary>
     public class JsonLdObjectContractResolver : DefaultContractResolver
     {
+        private bool _unsetConverter;
+
+        public JsonLdObjectContractResolver()
+         : this( false )
+        {
+        }
+
+        public JsonLdObjectContractResolver( bool unsetConverter )
+        {
+            _unsetConverter = unsetConverter;
+        }
+
         public override JsonContract ResolveContract(Type type)
         {
             if (typeof(JsonLdObject).IsAssignableFrom(type))
@@ -16,8 +28,11 @@ namespace LtiLibrary.Core.Common
                 var contract = base.ResolveContract(type);
                 
                 // Set the Convert to null to prevent recursive call to JsonLdObjectConverter
-                contract.Converter = null;
-
+                if ( _unsetConverter )
+                {
+                    contract.Converter = null;
+                }
+                
                 return contract;
             }
             return base.ResolveContract(type);

--- a/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
+++ b/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
@@ -54,7 +54,7 @@ namespace LtiLibrary.Core.Common
 
             // Use a new contract resolver to parse the object so that this
             // version of WriteJson is not called recursively
-            serializer.ContractResolver = new JsonLdObjectContractResolver();
+            serializer.ContractResolver = new JsonLdObjectContractResolver(true);
             serializer.DateFormatHandling = DateFormatHandling.IsoDateFormat;
             serializer.NullValueHandling = NullValueHandling.Ignore;
             var o = JObject.FromObject(value, serializer);

--- a/LtiLibrary.Core/Common/LtiConstants.cs
+++ b/LtiLibrary.Core/Common/LtiConstants.cs
@@ -104,7 +104,7 @@ namespace LtiLibrary.Core.Common
         public const string LineItemType = "LineItem";
         public const string LisResultType = "LISResult";
         public const string LisResultContainerType = "LisResultContainer";
-        public const string LtiLinkType = "LtiLink";
+        public const string LtiLinkType = "LtiLinkItem";
         public const string NumericLimitsType = "NumericLimits";
         public const string RestService = "RestService";
         public const string ToolConsumerProfileType = "ToolConsumerProfile";


### PR DESCRIPTION
Addresses two issues:
1. The @type for LtiLink was inconsistent with [the spec](https://www.imsglobal.org/specs/lticiv1p0/specification-3).  Solution was changing the string in LtiConstants.  I can see an argument that this is a breaking change, and could just add a new property with the correct value, but it seems like this was the intended use of the current property.
2. JsonLdObjectConverter was not being properly invoked when the ToJsonLdString extension was used because of loop-preventing code in JsonLdObjectContractResolver.  Tweaked it so the creator of the contract resolver can choose whether or not to use that behavior.  
   - Added a test for the extension method.
   - Refactored existing tests for JsonLdObject to use the extension method for validation.
