### PR TITLE
Invalid Validation of LTI message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ local.properties
 *.suo
 *.user
 *.sln.docstates
+*project.lock.json
 
 # Build results
 [Dd]ebug/

--- a/LtiLibrary.AspNet/Extensions/HttpRequestBaseExtensions.cs
+++ b/LtiLibrary.AspNet/Extensions/HttpRequestBaseExtensions.cs
@@ -28,8 +28,7 @@ namespace LtiLibrary.AspNet.Extensions
             {
                 LtiConstants.LtiMessageTypeParameter,
                 LtiConstants.LtiVersionParameter,
-                LtiConstants.ResourceLinkIdParameter,
-                LtiConstants.UserIdParameter
+                LtiConstants.ResourceLinkIdParameter
             };
 
         // These LTI Content Item parameters are required
@@ -39,8 +38,7 @@ namespace LtiLibrary.AspNet.Extensions
                 LtiConstants.AcceptPresentationDocumentTargetsParameter,
                 LtiConstants.ContentItemReturnUrlParameter,
                 LtiConstants.LtiMessageTypeParameter,
-                LtiConstants.LtiVersionParameter,
-                LtiConstants.UserIdParameter
+                LtiConstants.LtiVersionParameter
             };
 
         // These LTI Content Item parameters are required


### PR DESCRIPTION
Korporal noticed that LTI "user_id" (a recommended parameter) was treated as a required paremter (see Issue #27).

This pull request removes "user_id" from the required parameter validations.
