### PR TITLE
Net core updates

### DIFF
--- a/LtiLibrary.Core.Tests/SimpleHelpers/JsonAssertions.cs
+++ b/LtiLibrary.Core.Tests/SimpleHelpers/JsonAssertions.cs
@@ -45,8 +45,8 @@ namespace LtiLibrary.Core.Tests.SimpleHelpers
 
                var diff = ObjectDiffPatch.GenerateDiff( refJObject, eventJObject );
 
-               Debug.WriteLine( diff.NewValues );
-               Debug.WriteLine( diff.OldValues );
+               Trace.WriteLine( diff.NewValues );
+               Trace.WriteLine( diff.OldValues );
 
                Assert.Null( diff.NewValues );
                Assert.Null( diff.OldValues );

--- a/LtiLibrary.Core.Tests/SimpleHelpers/JsonAssertions.cs
+++ b/LtiLibrary.Core.Tests/SimpleHelpers/JsonAssertions.cs
@@ -45,8 +45,8 @@ namespace LtiLibrary.Core.Tests.SimpleHelpers
 
                var diff = ObjectDiffPatch.GenerateDiff( refJObject, eventJObject );
 
-               Trace.WriteLine( diff.NewValues );
-               Trace.WriteLine( diff.OldValues );
+               Debug.WriteLine( diff.NewValues );
+               Debug.WriteLine( diff.OldValues );
 
                Assert.Null( diff.NewValues );
                Assert.Null( diff.OldValues );

--- a/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
+++ b/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
@@ -64,8 +64,7 @@ namespace LtiLibrary.Core.Common
             // If there is only an external context, add a simple JProperty.
             if (externalContextId != null && (terms == null || terms.Count == 0))
             {
-                JToken context;
-                if (!o.TryGetValue("@context", StringComparison.InvariantCulture, out context))
+                if (!o.HasValues || o.First.Type != JTokenType.Property || !((JProperty) o.First).Name.Equals("@context"))
                 {
                     o.AddFirst(new JProperty("@context", externalContextId));
                 }

--- a/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
+++ b/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
@@ -64,7 +64,12 @@ namespace LtiLibrary.Core.Common
             // If there is only an external context, add a simple JProperty.
             if (externalContextId != null && (terms == null || terms.Count == 0))
             {
-                o.AddFirst(new JProperty("@context", externalContextId));
+                JToken context;
+                if (!o.TryGetValue("@context", StringComparison.InvariantCulture, out context))
+                {
+                    o.AddFirst(new JProperty("@context", externalContextId));
+                }
+                o["@context"] = externalContextId;
             }
             // If there are only terms, add a JObject with each term as a JProperty
             else if (externalContextId == null && terms != null && terms.Count > 0)

--- a/LtiLibrary.Core/Extensions/HttpExtensions.cs
+++ b/LtiLibrary.Core/Extensions/HttpExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -17,14 +18,10 @@ namespace LtiLibrary.Core.Extensions
             }
         }
 
+        [Obsolete("Use GetResponseAsync instead.")]
         public static HttpResponseMessage GetResponse(this HttpRequestMessage message, bool allowAutoRedirect = false)
         {
             return GetResponseAsync(message, allowAutoRedirect).Result;
-        }
-
-        public static Stream GetRequestStream(this HttpRequestMessage message)
-        {
-            return message.Content.ReadAsStreamAsync().Result;
         }
 
         public static Stream GetResponseStream(this HttpResponseMessage message)

--- a/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
+++ b/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
@@ -12,7 +12,7 @@ namespace LtiLibrary.Core.Extensions
         /// Create a string representation of the <see cref="HttpWebRequest"/> similar to Fiddler's.
         /// </summary>
         /// <remarks>Created for learning and debugging LTI.</remarks>
-        public static async Task<string> ToFormattedRequestString(this HttpRequestMessage request)
+        public static async Task<string> ToFormattedRequestStringAsync(this HttpRequestMessage request)
         {
             var sb = new StringBuilder();
             sb.AppendFormat("{0} {1} HTTP/1.1\n", request.Method, request.RequestUri);

--- a/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
+++ b/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace LtiLibrary.Core.Extensions
 {
@@ -11,7 +12,7 @@ namespace LtiLibrary.Core.Extensions
         /// Create a string representation of the <see cref="HttpWebRequest"/> similar to Fiddler's.
         /// </summary>
         /// <remarks>Created for learning and debugging LTI.</remarks>
-        public static string ToFormattedRequestString(this HttpRequestMessage request)
+        public static async Task<string> ToFormattedRequestString(this HttpRequestMessage request)
         {
             var sb = new StringBuilder();
             sb.AppendFormat("{0} {1} HTTP/1.1\n", request.Method, request.RequestUri);
@@ -22,7 +23,7 @@ namespace LtiLibrary.Core.Extensions
             if (request.Content.Headers.ContentLength > 0)
             {
                 sb.AppendLine();
-                using (var stream = request.GetRequestStream())
+                using (var stream = await request.Content.ReadAsStreamAsync())
                 {
                     if (stream.CanRead)
                     {

--- a/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
+++ b/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
@@ -20,23 +20,10 @@ namespace LtiLibrary.Core.Extensions
             {
                 sb.AppendFormat("{0}: {1}\n", header.Key, string.Join(",", header.Value ?? new string[]{}));
             }
-            if (request.Content.Headers.ContentLength > 0)
+            if (request.Content != null && request.Content.Headers.ContentLength > 0)
             {
                 sb.AppendLine();
-                using (var stream = await request.Content.ReadAsStreamAsync())
-                {
-                    if (stream.CanRead)
-                    {
-                        using (var reader = new StreamReader(stream))
-                        {
-                            sb.Append(reader.ReadToEnd());
-                        }
-                        if (stream.CanSeek)
-                        {
-                            stream.Position = 0;
-                        }
-                    }
-                }
+                sb.Append(await request.Content.ReadAsStringAsync());
             }
             return sb.ToString();
         }

--- a/LtiLibrary.Core/LtiLibrary.Core.csproj
+++ b/LtiLibrary.Core/LtiLibrary.Core.csproj
@@ -40,7 +40,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <DocumentationFile>bin\Release\LtiLibrary.Core.xml</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
@@ -3,14 +3,12 @@ using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
 using System.Net;
-using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Serialization;
 using LtiLibrary.Core.Common;
 using LtiLibrary.Core.Extensions;
 using LtiLibrary.Core.OAuth;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace LtiLibrary.Core.Outcomes.v1

--- a/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
@@ -281,7 +281,6 @@ namespace LtiLibrary.Core.Outcomes.v1
             parameters.AddParameter(OAuthConstants.TimestampParameter, timestamp);
 
             // Calculate the body hash
-            //using (var ms = new MemoryStream())
             var ms = new MemoryStream();
             using (var sha1 = PlatformSpecific.GetSha1Provider())
             {

--- a/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
@@ -305,7 +305,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             {
                 authorization.AppendFormat("{0}=\"{1}\",", key, WebUtility.UrlEncode(parameters[key]));
             }
-            webRequest.Content.Headers.Add(OAuthConstants.AuthorizationHeader, authorization.ToString(0, authorization.Length - 1));
+            webRequest.Headers.Add(OAuthConstants.AuthorizationHeader, authorization.ToString(0, authorization.Length - 1));
 
             return webRequest;
         }

--- a/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
@@ -36,7 +36,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0");
         }
 
-        public static async Task<BasicResult> DeleteScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
+        public static async Task<BasicResult> DeleteScoreAsync(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {
@@ -70,7 +70,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             }
         }
 
-        public static async Task<BasicResult> PostScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId, double? score)
+        public static async Task<BasicResult> PostScoreAsync(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId, double? score)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {
@@ -192,7 +192,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                 imsxHeader.imsx_statusInfo.imsx_description);
         }
 
-        public static async Task<LisResult> ReadScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
+        public static async Task<LisResult> ReadScoreAsync(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {

--- a/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
@@ -38,7 +38,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0");
         }
 
-        public static BasicResult DeleteScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
+        public static async Task<BasicResult> DeleteScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {
@@ -63,7 +63,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     serviceUrl,
                     consumerKey,
                     consumerSecret);
-                var webResponse = webRequest.GetResponse();
+                var webResponse = await webRequest.GetResponseAsync();
                 return ParseDeleteResultResponse(webResponse);
             }
             catch (Exception ex)
@@ -72,7 +72,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             }
         }
 
-        public static BasicResult PostScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId, double? score)
+        public static async Task<BasicResult> PostScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId, double? score)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {
@@ -110,7 +110,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     serviceUrl,
                     consumerKey,
                     consumerSecret);
-                var webResponse = webRequest.GetResponse();
+                var webResponse = await webRequest.GetResponseAsync();
                 return ParsePostResultResponse(webResponse);
             }
             catch (Exception ex)
@@ -194,7 +194,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                 imsxHeader.imsx_statusInfo.imsx_description);
         }
 
-        public static LisResult ReadScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
+        public static async Task<LisResult> ReadScore(string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
         {
             var imsxEnvelope = new imsx_POXEnvelopeType
             {
@@ -219,7 +219,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     serviceUrl,
                     consumerKey,
                     consumerSecret);
-                var webResponse = webRequest.GetResponse();
+                var webResponse = await webRequest.GetResponseAsync();
                 return ParseReadResultResponse(webResponse);
             }
             catch (Exception ex)
@@ -281,7 +281,8 @@ namespace LtiLibrary.Core.Outcomes.v1
             parameters.AddParameter(OAuthConstants.TimestampParameter, timestamp);
 
             // Calculate the body hash
-            using (var ms = new MemoryStream())
+            //using (var ms = new MemoryStream())
+            var ms = new MemoryStream();
             using (var sha1 = PlatformSpecific.GetSha1Provider())
             {
                 ImsxRequestSerializer.Serialize(ms, imsxEnvelope);

--- a/LtiLibrary.Core/Outcomes/v2/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v2/OutcomesClient.cs
@@ -233,7 +233,7 @@ namespace LtiLibrary.Core.Outcomes.v2
 #if DEBUG
                 finally
                 {
-                    outcomeResponse.HttpRequest = request.ToFormattedRequestString();
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(null);
@@ -281,7 +281,7 @@ namespace LtiLibrary.Core.Outcomes.v2
                 finally
                 {
 #if DEBUG
-                    outcomeResponse.HttpRequest = request.ToFormattedRequestString();
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(
@@ -359,7 +359,7 @@ namespace LtiLibrary.Core.Outcomes.v2
                 finally
                 {
 #if DEBUG
-                    outcomeResponse.HttpRequest = request.ToFormattedRequestString();
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(
@@ -412,7 +412,7 @@ namespace LtiLibrary.Core.Outcomes.v2
                 finally
                 {
 #if DEBUG
-                    outcomeResponse.HttpRequest = request.ToFormattedRequestString();
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(null);

--- a/LtiLibrary.Core/Outcomes/v2/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v2/OutcomesClient.cs
@@ -208,10 +208,6 @@ namespace LtiLibrary.Core.Outcomes.v2
             try
             {
                 var request = new HttpRequestMessage(HttpMethod.Delete, serviceUrl);
-                if (!string.IsNullOrWhiteSpace(contentType))
-                {
-                    request.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-                }
 
                 SignRequest(request, null, consumerKey, consumerSecret);
 
@@ -219,6 +215,11 @@ namespace LtiLibrary.Core.Outcomes.v2
                 HttpResponseMessage response = null;
                 try
                 {
+#if DEBUG
+                    // Capture the request in human readable form for debugging
+                    // and inspection while learning
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+#endif
                     response = await request.GetResponseAsync();
                     outcomeResponse.StatusCode = response.StatusCode;
                 }
@@ -233,7 +234,8 @@ namespace LtiLibrary.Core.Outcomes.v2
 #if DEBUG
                 finally
                 {
-                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+                    // Capture the response in human readable form for debugging
+                    // and inspection while learning
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(null);
@@ -263,6 +265,11 @@ namespace LtiLibrary.Core.Outcomes.v2
                 HttpResponseMessage response = null;
                 try
                 {
+#if DEBUG
+                    // Capture the request in human readable form for debugging
+                    // and inspection while learning
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+#endif
                     response = await request.GetResponseAsync(allowAutoRedirect: true);
                     outcomeResponse.StatusCode = response.StatusCode;
                     if (response.StatusCode == HttpStatusCode.OK)
@@ -281,7 +288,8 @@ namespace LtiLibrary.Core.Outcomes.v2
                 finally
                 {
 #if DEBUG
-                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+                    // Capture the response in human readable form for debugging
+                    // and inspection while learning
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(
@@ -330,10 +338,10 @@ namespace LtiLibrary.Core.Outcomes.v2
             try
             {
                 var request = new HttpRequestMessage(HttpMethod.Post, serviceUrl);
-                request.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
 
                 var body = Encoding.UTF8.GetBytes(outcome.ToJsonLdString());
                 request.Content = new ByteArrayContent(body);
+                request.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
 
                 SignRequest(request, body, consumerKey, consumerSecret);
 
@@ -341,6 +349,11 @@ namespace LtiLibrary.Core.Outcomes.v2
                 HttpResponseMessage response = null;
                 try
                 {
+#if DEBUG
+                    // Capture the request in human readable form for debugging
+                    // and inspection while learning
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+#endif
                     response = await request.GetResponseAsync();
                     outcomeResponse.StatusCode = response.StatusCode;
                     if (response.StatusCode == HttpStatusCode.Created)
@@ -359,7 +372,8 @@ namespace LtiLibrary.Core.Outcomes.v2
                 finally
                 {
 #if DEBUG
-                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+                    // Capture the response in human readable form for debugging
+                    // and inspection while learning
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(
@@ -387,10 +401,10 @@ namespace LtiLibrary.Core.Outcomes.v2
             try
             {
                 var request = new HttpRequestMessage(HttpMethod.Put, serviceUrl);
-                request.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
 
                 var body = Encoding.UTF8.GetBytes(outcome.ToJsonLdString());
                 request.Content = new ByteArrayContent(body);
+                request.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
 
                 SignRequest(request, body, consumerKey, consumerSecret);
 
@@ -398,6 +412,11 @@ namespace LtiLibrary.Core.Outcomes.v2
                 HttpResponseMessage response = null;
                 try
                 {
+#if DEBUG
+                    // Capture the request in human readable form for debugging
+                    // and inspection while learning
+                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+#endif
                     response = await request.GetResponseAsync();
                     outcomeResponse.StatusCode = response.StatusCode;
                 }
@@ -412,7 +431,8 @@ namespace LtiLibrary.Core.Outcomes.v2
                 finally
                 {
 #if DEBUG
-                    outcomeResponse.HttpRequest = await request.ToFormattedRequestStringAsync();
+                    // Capture the response in human readable form for debugging
+                    // and inspection while learning
                     if (response != null)
                     {
                         outcomeResponse.HttpResponse = response.ToFormattedResponseString(null);
@@ -466,7 +486,7 @@ namespace LtiLibrary.Core.Outcomes.v2
             {
                 authorization.AppendFormat("{0}=\"{1}\",", key, WebUtility.UrlEncode(parameters[key]));
             }
-            request.Content.Headers.Add(OAuthConstants.AuthorizationHeader, authorization.ToString(0, authorization.Length - 1));
+            request.Headers.Add(OAuthConstants.AuthorizationHeader, authorization.ToString(0, authorization.Length - 1));
         }
 
         #endregion


### PR DESCRIPTION
This pull request has additional changes to @xferra [pull request 25](https://github.com/andyfmiller/LtiLibrary/pull/25). These changes are necessary to make the [LtiSamples](https://github.com/andyfmiller/LtiSamples) work. The significant changes are:

- Convert OutcomesClient methods to async to avoid deadlocks (new http client is less relaxed about it)
- Fix up the Json-LD formatter so that only one @context element is generated
- Use HttpRequestHeader instead of a content HttpHeader where appropriate (new http client is less relaxed about it)
- Stop disposing the content stream after calculating signature (new http client is less relaxed about it)