### PR TITLE
V2.0.2

### DIFF
--- a/LtiLibrary.AspNetCore.Tests/Lti1/ProviderController.cs
+++ b/LtiLibrary.AspNetCore.Tests/Lti1/ProviderController.cs
@@ -19,18 +19,19 @@ namespace LtiLibrary.AspNetCore.Tests.Lti1
         {
             try
             {
+                // Parse and validate the request
+                var ltiRequest = await Request.ParseLtiRequestAsync();
+
                 // Make sure this is an LtiRequest
                 try
                 {
-                    Request.CheckForRequiredLtiFormParameters();
+                    ltiRequest.CheckForRequiredLtiParameters();
                 }
                 catch (Exception ex)
                 {
                     return BadRequest(ex);
                 }
 
-                // Parse and validate the request
-                var ltiRequest = await Request.ParseLtiRequestAsync();
 
                 if (!ltiRequest.ConsumerKey.Equals("12345"))
                 {
@@ -62,18 +63,18 @@ namespace LtiLibrary.AspNetCore.Tests.Lti1
         {
             try
             {
+                // Parse and validate the request
+                var ltiRequest = await Request.ParseLtiRequestAsync();
+
                 // Make sure this is an LtiRequest
                 try
                 {
-                    Request.CheckForRequiredLtiFormParameters();
+                    ltiRequest.CheckForRequiredLtiParameters();
                 }
                 catch (Exception ex)
                 {
                     return BadRequest(ex);
                 }
-
-                // Parse and validate the request
-                var ltiRequest = await Request.ParseLtiRequestAsync();
 
                 if (!ltiRequest.ConsumerKey.Equals("12345"))
                 {

--- a/LtiLibrary.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/LtiLibrary.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,64 +11,6 @@ namespace LtiLibrary.AspNetCore.Extensions
 {
     public static class HttpRequestExtensions
     {
-        // These OAuth parameters are required
-        private static readonly string[] RequiredOauthParameters =
-            {
-                OAuthConstants.ConsumerKeyParameter,
-                OAuthConstants.NonceParameter,
-                OAuthConstants.SignatureParameter,
-                OAuthConstants.SignatureMethodParameter,
-                OAuthConstants.TimestampParameter,
-                OAuthConstants.VersionParameter
-            };
-
-        // These LTI launch parameters are required
-        private static readonly string[] RequiredBasicLaunchParameters =
-            {
-                LtiConstants.LtiMessageTypeParameter,
-                LtiConstants.LtiVersionParameter,
-                LtiConstants.ResourceLinkIdParameter
-            };
-
-        // These LTI Content Item parameters are required
-        private static readonly string[] RequiredContentItemLaunchParameters =
-            {
-                LtiConstants.AcceptMediaTypesParameter,
-                LtiConstants.AcceptPresentationDocumentTargetsParameter,
-                LtiConstants.ContentItemReturnUrlParameter,
-                LtiConstants.LtiMessageTypeParameter,
-                LtiConstants.LtiVersionParameter
-            };
-
-        // These LTI Content Item parameters are required
-        private static readonly string[] RequiredContentItemResponseParameters =
-            {
-                LtiConstants.ContentItemPlacementParameter
-            };
-
-        public static LisContextType? GetLisContextType(this HttpRequest request, string key)
-        {
-            var stringValue = request.Form[key];
-            LisContextType contextTypeEnum;
-            return Enum.TryParse(stringValue, out contextTypeEnum)
-                       ? contextTypeEnum
-                       : default(LisContextType?);
-        }
-
-        public static DocumentTarget? GetPresentationTarget(this HttpRequest request, string key)
-        {
-            var stringValue = request.Form[key];
-            DocumentTarget presentationTargetEnum;
-            return Enum.TryParse(stringValue, out presentationTargetEnum)
-                       ? presentationTargetEnum
-                       : default(DocumentTarget?);
-        }
-
-        //private static string GetUnvalidatedString(this HttpRequest request, string key)
-        //{
-        //    return request.Unvalidated[key];
-        //}
-
         /// <summary>
         /// Get a value indicating whether the current request is authenticated
         /// using LTI.
@@ -93,41 +34,6 @@ namespace LtiLibrary.AspNetCore.Extensions
 
             // Otherwise look for an OAuth Authorization header
             return request.ParseAuthenticationHeader().HasKeys();
-        }
-
-        /// <summary>
-        /// Parse the HttpRequest and return a filled in LtiRequest.
-        /// </summary>
-        /// <param name="request">The HttpRequest to parse.</param>
-        /// <returns>An LtiInboundRequest filled in with the OAuth and LTI parameters
-        /// sent by the consumer.</returns>
-        public static void CheckForRequiredLtiFormParameters(this HttpRequest request)
-        {
-            if (!request.IsAuthenticatedWithLti())
-            {
-                throw new LtiException("Invalid LTI request.");
-            }
-
-            // Make sure the request contains all the required parameters
-            request.RequireAllOf(RequiredOauthParameters);
-            switch (request.Form[LtiConstants.LtiMessageTypeParameter])
-            {
-                case LtiConstants.BasicLaunchLtiMessageType:
-                    {
-                        request.RequireAllOf(RequiredBasicLaunchParameters);
-                        break;
-                    }
-                case LtiConstants.ContentItemSelectionRequestLtiMessageType:
-                    {
-                        request.RequireAllOf(RequiredContentItemLaunchParameters);
-                        break;
-                    }
-                case LtiConstants.ContentItemSelectionLtiMessageType:
-                    {
-                        request.RequireAllOf(RequiredContentItemResponseParameters);
-                        break;
-                    }
-            }
         }
 
         private static NameValueCollection ParseAuthenticationHeader(this HttpRequest request)
@@ -185,16 +91,6 @@ namespace LtiLibrary.AspNetCore.Extensions
                 ltiRequest.BodyHashReceived = request.Headers["BodyHash"].First();
             }
             return ltiRequest;
-        }
-
-        public static void RequireAllOf(this HttpRequest request, IEnumerable<string> parameters)
-        {
-            var missing = parameters.Where(parameter => string.IsNullOrEmpty(request.Form[parameter])).ToList();
-
-            if (missing.Count > 0)
-            {
-                throw new LtiException("Missing parameters: " + string.Join(", ", missing.ToArray()));
-            }
         }
 
         public static Uri GetUri(this HttpRequest request)

--- a/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
+++ b/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <Description>ASP.NET Core library with IMS LTI support for Tool Consumer and Tool Provider applications. Supports IMS LTI 1.0, 1.1, 1.1.1 and 1.2; Outcomes 1.0; Outcomes 2.0 (Draft); and Content-Item Message 1.0.</Description>
     <Copyright>Copyright 2017</Copyright>
     <AssemblyTitle>LtiLibrary.AspNetCore</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <Authors>andyfmiller.com</Authors>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
@@ -17,6 +17,8 @@
 - New library for ASP.NET Core
 2.0.1-beta
 - Fixed minor bugs discovered by integration tests.
+2.0.2-beta
+- Merged fix to issue #39.
       ]]>
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/andyfmiller/LtiLibrary</PackageProjectUrl>

--- a/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
+++ b/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.ContentItems;
 using LtiLibrary.NetCore.Extensions;
@@ -191,6 +192,40 @@ namespace LtiLibrary.NetCore.Tests
                 };
             var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
             Assert.Equal($"Missing parameter(s): {LtiConstants.ContentItemPlacementParameter}.", ex.Message);
+        }
+
+        [Fact]
+        public void GenerateAKnownSignature_GivenKnownParameters()
+        {
+            var request = new LtiRequest
+            {
+                CallBack = "about:blank",
+                ConsumerKey = "12345",
+                ContextId = "1219",
+                ContextTitle = "docker",
+                ContextType = LisContextType.CourseTemplate,
+                HttpMethod = HttpMethod.Post.Method,
+                LaunchPresentationLocale = "en-US",
+                LisPersonNameFamily = "Miller",
+                LisPersonNameGiven = "Andy",
+                LtiMessageType = "basic-lti-launch-request",
+                LtiVersion = "LTI-1p0",
+                Nonce = "c5c9781bfc3e4a1fb11b09ac119c860c",
+                ResourceLinkId = "3280",
+                ResourceLinkTitle = "docker",
+                Roles = "Instructor,Learner",
+                SignatureMethod = "HMAC-SHA1",
+                Timestamp = 1492745602,
+                ToolConsumerInfoProductFamilyCode = "Consumer",
+                ToolConsumerInfoVersion = "1.5.0.0",
+                ToolConsumerInstanceGuid = "http://consumer.azurewebsites.net/",
+                ToolConsumerInstanceName = "Consumer Sample",
+                Url = new Uri("http://localhost:32768/home/tool?one=one"),
+                UserId = "98befcbc-117d-4328-9c70-93d198e44ddc",
+                Version = "1.0"
+            };
+            var signature = request.GenerateSignature("secret");
+            Assert.Equal("Im/RhYIEApfbsy+luuisvQqBjgs=", signature);
         }
     }
 }

--- a/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
+++ b/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.ContentItems;
 using LtiLibrary.NetCore.Extensions;
@@ -35,7 +33,7 @@ namespace LtiLibrary.NetCore.Tests
                 ResourceLinkId = "launch"
             };
             var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
-            Assert.Equal($"Invalid HTTP method: null.", ex.Message);
+            Assert.Equal("Invalid HTTP method: null.", ex.Message);
         }
 
         [Fact]

--- a/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
+++ b/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using LtiLibrary.NetCore.Common;
+using LtiLibrary.NetCore.ContentItems;
+using LtiLibrary.NetCore.Extensions;
+using LtiLibrary.NetCore.Lti1;
+using LtiLibrary.NetCore.OAuth;
+using Xunit;
+
+namespace LtiLibrary.NetCore.Tests
+{
+    public class LtiRequestShould
+    {
+        [Fact]
+        public void GenerateSignature_IfBasicLaunchRequestHasAllRequiredFields()
+        {
+            var request =
+                new LtiRequest(LtiConstants.BasicLaunchLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345",
+                    ResourceLinkId = "launch"
+                };
+            request.Signature = request.SubstituteCustomVariablesAndGenerateSignature("secret");
+        }
+
+        [Fact]
+        public void ThrowException_IfMessageTypeIsMissing()
+        {
+            var request = new LtiRequest
+            {
+                Url = new Uri("http://lti.tools/test/tp.php"),
+                ConsumerKey = "12345",
+                ResourceLinkId = "launch"
+            };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Invalid HTTP method: null.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowException_IfMessageTypeIsUnknown()
+        {
+            var request = new LtiRequest("wrong")
+            {
+                Url = new Uri("http://lti.tools/test/tp.php"),
+                ConsumerKey = "12345",
+                ResourceLinkId = "launch"
+            };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Invalid {LtiConstants.LtiMessageTypeParameter}: wrong.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowException_UrlIsMissing()
+        {
+            var request = new LtiRequest(LtiConstants.BasicLaunchLtiMessageType)
+            {
+                ConsumerKey = "12345",
+                ResourceLinkId = "launch"
+            };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal("Missing parameter(s): Url.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowException_IfConsumerKeyIsMissing()
+        {
+            var request = new LtiRequest(LtiConstants.BasicLaunchLtiMessageType)
+            {
+                Url = new Uri("http://lti.tools/test/tp.php"),
+                ResourceLinkId = "launch"
+            };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Missing parameter(s): {OAuthConstants.ConsumerKeyParameter}.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowException_IfBasicLaunchRequestIsMissingResourceLinkId()
+        {
+            var request = new LtiRequest(LtiConstants.BasicLaunchLtiMessageType)
+            {
+                Url = new Uri("http://lti.tools/test/tp.php"),
+                ConsumerKey = "12345"
+            };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Missing parameter(s): {LtiConstants.ResourceLinkIdParameter}.", ex.Message);
+        }
+
+        [Fact]
+        public void GenerateSignature_IfContentItemLaunchRequestHasAllRequiredFields()
+        {
+            var request =
+                new LtiRequest(LtiConstants.ContentItemSelectionRequestLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345",
+                    AcceptMediaTypes = "text/html",
+                    AcceptPresentationDocumentTargets = DocumentTarget.frame.ToString(),
+                    ContentItemReturnUrl = "http://localhost/content"
+
+                };
+            request.Signature = request.SubstituteCustomVariablesAndGenerateSignature("secret");
+        }
+
+        [Fact]
+        public void ThrowException_IfContentItemLaunchIsMissingAcceptMediaTypes()
+        {
+            var request =
+                new LtiRequest(LtiConstants.ContentItemSelectionRequestLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345",
+                    AcceptPresentationDocumentTargets = DocumentTarget.frame.ToString(),
+                    ContentItemReturnUrl = "http://localhost/content"
+
+                };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Missing parameter(s): {LtiConstants.AcceptMediaTypesParameter}.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowException_IfContentItemLaunchIsMissingAcceptPresentationDocumentTargets()
+        {
+            var request =
+                new LtiRequest(LtiConstants.ContentItemSelectionRequestLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345",
+                    AcceptMediaTypes = "text/html",
+                    ContentItemReturnUrl = "http://localhost/content"
+                };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Missing parameter(s): {LtiConstants.AcceptPresentationDocumentTargetsParameter}.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowException_IfContentItemLaunchIsMissingContentItemReturnUrl()
+        {
+            var request =
+                new LtiRequest(LtiConstants.ContentItemSelectionRequestLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345",
+                    AcceptMediaTypes = "text/html",
+                    AcceptPresentationDocumentTargets = DocumentTarget.frame.ToString()
+                };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Missing parameter(s): {LtiConstants.ContentItemReturnUrlParameter}.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowException_IfContentItemLaunchUrlIsInvalid()
+        {
+            var request =
+                new LtiRequest(LtiConstants.ContentItemSelectionRequestLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345",
+                    AcceptMediaTypes = "text/html",
+                    AcceptPresentationDocumentTargets = DocumentTarget.frame.ToString(),
+                    ContentItemReturnUrl = "w:r:o:n:g"
+                };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Invalid {LtiConstants.ContentItemReturnUrlParameter}: w:r:o:n:g.", ex.Message);
+        }
+
+        [Fact]
+        public void GenerateSignature_IfContentItemLaunchResponsetHasAllRequiredFields()
+        {
+            var request =
+                new LtiRequest(LtiConstants.ContentItemSelectionLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345",
+                    ContentItems = new ContentItem
+                    {
+                        MediaType = "text/html",
+                        Text = "<p>Text</p>"
+                    }.ToJsonLdString()
+                };
+            request.Signature = request.SubstituteCustomVariablesAndGenerateSignature("secret");
+        }
+
+        [Fact]
+        public void ThrowException_IfContentItemResponseIsMissingContentItems()
+        {
+            var request =
+                new LtiRequest(LtiConstants.ContentItemSelectionLtiMessageType)
+                {
+                    Url = new Uri("http://lti.tools/test/tp.php"),
+                    ConsumerKey = "12345"
+                };
+            var ex = Assert.Throws<LtiException>(() => request.SubstituteCustomVariablesAndGenerateSignature("secret"));
+            Assert.Equal($"Missing parameter(s): {LtiConstants.ContentItemPlacementParameter}.", ex.Message);
+        }
+    }
+}

--- a/LtiLibrary.NetCore/LtiLibrary.NetCore.csproj
+++ b/LtiLibrary.NetCore/LtiLibrary.NetCore.csproj
@@ -4,7 +4,7 @@
     <Description>.NET Core library with IMS LTI support for Tool Consumer and Tool Provider applications. Supports IMS LTI 1.0, 1.1, 1.1.1 and 1.2; Outcomes 1.0; Outcomes 2.0 (Draft); and Content-Item Message 1.0.</Description>
     <Copyright>Copyright 2017</Copyright>
     <AssemblyTitle>LtiLibrary.NetCore</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <Authors>andyfmiller.com</Authors>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
@@ -17,6 +17,8 @@
 - Updated to .NET Core 1.1
 2.0.1-beta
 - Changed interface of v1.OutcomesClient, v2.OutcomesClient, and ToolConsumerProfileClient to take an HttpClient. This facilitated using Microsoft.AspNetCore.TestHost for integration testing.
+2.0.2-beta
+- Merged fix to issue #39.
       ]]>
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/andyfmiller/LtiLibrary</PackageProjectUrl>


### PR DESCRIPTION
- Merged in changes for Issue #39 (allow check for required parameters before sending request) and moved required parameter checks from HttpRequestExentions to LtiRequest. So before this change you would check incoming Request for required parameters then parse it into an LtiRequest. Now you parse the request into an LtiRequest, the check for required parameters. This also means you can check an outgoing request for required parameters before you send it.
- Added LtiRequest tests, mostly around required parameters, but also signature generation.