### PR TITLE
2.1.2

### DIFF
--- a/LtiLibrary.AspNetCore.Tests/Outcomes/v1/RawOutcomesController.cs
+++ b/LtiLibrary.AspNetCore.Tests/Outcomes/v1/RawOutcomesController.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using LtiLibrary.NetCore.Lti.v1;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LtiLibrary.AspNetCore.Tests.Outcomes.v1
+{
+    /// <summary>
+    /// This version of the OutcomesController does not use model binding so that
+    /// it can inspect the raw data in the request.
+    /// </summary>
+    [Consumes("application/xml")]
+    [Produces("text/plain")]
+    [Route("ims/rawoutcomes", Name = "RawOutcomesApi")]
+    public class RawOutcomesController : Controller
+    {
+        private static readonly XmlSerializer ImsxResponseSerializer = new XmlSerializer(typeof(imsx_POXEnvelopeType),
+            null, null, new XmlRootAttribute("imsx_POXEnvelopeResponse"),
+            "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0");
+
+        /// <summary>
+        /// All Outcomes1Client requests are handled by this one action
+        /// </summary>
+        public async Task<IActionResult> Post()
+        {
+            var contentEncoding = GetContentEncoding(Request.ContentType);
+
+            if (Request.Body.CanSeek)
+            {
+                Request.Body.Position = 0;
+            }
+            if (Request.Body.CanRead)
+            {
+                var reader = new StreamReader(Request.Body);
+                var xml = await reader.ReadToEndAsync();
+
+                if (string.IsNullOrWhiteSpace(xml))
+                {
+                    return BadRequest();
+                }
+
+                var doc = new XmlDocument();
+                doc.LoadXml(xml);
+
+                var declaration = doc.FirstChild as XmlDeclaration;
+                if (declaration == null)
+                {
+                    return BadRequest();
+                }
+
+                if (!contentEncoding.Equals(declaration.Encoding))
+                {
+                    return BadRequest();
+                }
+            }
+            return await CreateSuccessResponse();
+        }
+
+        /// <summary>
+        /// Create a simple, but complete response envelope. The status is set to success.
+        /// </summary>
+        private static async Task<ObjectResult> CreateSuccessResponse()
+        {
+            var response = new imsx_POXEnvelopeType
+            {
+                imsx_POXHeader = new imsx_POXHeaderType { Item = new imsx_ResponseHeaderInfoType() },
+                imsx_POXBody = new imsx_POXBodyType { Item = new readResultResponse() }
+            };
+
+            var item = (imsx_ResponseHeaderInfoType)response.imsx_POXHeader.Item;
+            item.imsx_version = imsx_GWSVersionValueType.V10;
+            item.imsx_messageIdentifier = Guid.NewGuid().ToString();
+            item.imsx_statusInfo = new imsx_StatusInfoType();
+
+            var status = item.imsx_statusInfo;
+            status.imsx_codeMajor = imsx_CodeMajorType.success;
+            status.imsx_severity = imsx_SeverityType.status;
+
+            using (var ms = new MemoryStream())
+            {
+                ImsxResponseSerializer.Serialize(ms, response);
+                using (var reader = new StreamReader(ms))
+                {
+                    ms.Position = 0;
+                    return new ObjectResult(await reader.ReadToEndAsync());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the encoding from the Content-Type header.
+        /// </summary>
+        private static string GetContentEncoding(string contentType)
+        {
+            if (!contentType.Contains("charset="))
+            {
+                return "utf-8";
+            }
+
+            var index = contentType.IndexOf("charset=", StringComparison.Ordinal);
+            var encoding = contentType.Substring(index + "charset=".Length);
+            if (encoding.Contains(";"))
+            {
+                encoding = encoding.Substring(0, encoding.IndexOf(";", StringComparison.Ordinal));
+            }
+            return encoding;
+        }
+    }
+}

--- a/LtiLibrary.AspNetCore.Tests/Outcomes/v1/RawOutcomesControllerShould.cs
+++ b/LtiLibrary.AspNetCore.Tests/Outcomes/v1/RawOutcomesControllerShould.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using LtiLibrary.NetCore.Clients;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.PlatformAbstractions;
+using Xunit;
+
+namespace LtiLibrary.AspNetCore.Tests.Outcomes.v1
+{
+    public class RawOutcomesControllerShould : IDisposable
+    {
+        private readonly TestServer _server;
+        private readonly HttpClient _client;
+
+        private const string Url = "ims/rawoutcomes";
+        private const string Key = "12345";
+        private const string Secret = "secret";
+        private const string Id = "testId";
+        private const double Value = 0.5;
+
+        public RawOutcomesControllerShould()
+        {
+            _server = new TestServer(new WebHostBuilder().UseStartup<Startup>());
+            _client = _server.CreateClient();
+
+            // Set the current directory to the compiler output directory so that
+            // the reference json is found
+            Directory.SetCurrentDirectory(PlatformServices.Default.Application.ApplicationBasePath);
+        }
+
+        [Fact]
+        public async Task Use_same_encoding_for_ContentType_and_Xml_for_DeleteResult()
+        {
+            var result = await Outcomes1Client.DeleteResultAsync(_client, Url, Key, Secret, Id);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task Use_same_encoding_for_ContentType_and_Xml_for_ReadResult()
+        {
+            var result = await Outcomes1Client.ReadResultAsync(_client, Url, Key, Secret, Id);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task Use_same_encoding_for_ContentType_and_Xml_for_ReplaceResult()
+        {
+            var result = await Outcomes1Client.ReplaceResultAsync(_client, Url, Key, Secret, Id, Value);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        public void Dispose()
+        {
+            _client?.Dispose();
+            _server?.Dispose();
+        }
+    }
+}

--- a/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Serialization;
 using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.Extensions;
@@ -70,15 +71,14 @@ namespace LtiLibrary.NetCore.Clients
                 {
                     client.DefaultRequestHeaders.Accept.Clear();
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    var xml = new StringBuilder();
-                    using (var writer = new StringWriter(xml))
-                    {
-                        ImsxRequestSerializer.Serialize(writer, imsxEnvelope);
-                        await writer.FlushAsync();
-                    }
-                    var httpContent = new StringContent(xml.ToString(), Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, httpContent, consumerKey, consumerSecret);
-                    using (var response = await client.PostAsync(serviceUrl, httpContent))
+
+                    // Create a UTF8 encoding of the request
+                    var xml = await GetXmlAsync(imsxEnvelope);
+                    var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret);
+
+                    // Post the request and check the response
+                    using (var response = await client.PostAsync(serviceUrl, xmlContent))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.IsSuccessStatusCode)
@@ -92,7 +92,7 @@ namespace LtiLibrary.NetCore.Clients
                                 : HttpStatusCode.BadRequest;
                         }
 #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync();
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync(new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType));
                         outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync();
 #endif
                     }
@@ -153,15 +153,14 @@ namespace LtiLibrary.NetCore.Clients
                 {
                     client.DefaultRequestHeaders.Accept.Clear();
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    var xml = new StringBuilder();
-                    using (var writer = new StringWriter(xml))
-                    {
-                        ImsxRequestSerializer.Serialize(writer, imsxEnvelope);
-                        await writer.FlushAsync();
-                    }
-                    var httpContent = new StringContent(xml.ToString(), Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, httpContent, consumerKey, consumerSecret);
-                    using (var response = await client.PostAsync(serviceUrl, httpContent))
+
+                    // Create a UTF8 encoding of the request
+                    var xml = await GetXmlAsync(imsxEnvelope);
+                    var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret);
+
+                    // Post the request and check the response
+                    using (var response = await client.PostAsync(serviceUrl, xmlContent))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.IsSuccessStatusCode)
@@ -190,7 +189,7 @@ namespace LtiLibrary.NetCore.Clients
                             }
                         }
     #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync(new StringContent(xml.ToString(), Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType));
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync(new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType));
                         outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync();
     #endif
                     }
@@ -250,28 +249,27 @@ namespace LtiLibrary.NetCore.Clients
                         resultScore = new TextType
                         {
                             language = LtiConstants.ScoreLanguage,
+                            // The LTI 1.1 specification states in 6.1.1. that the score in replaceResult should
+                            // always be formatted using “en” formatting
+                            // (http://www.imsglobal.org/LTI/v1p1p1/ltiIMGv1p1p1.html#_Toc330273034).
                             textString = score?.ToString(new CultureInfo(LtiConstants.ScoreLanguage))
                         }
                     }
                 };
-                // The LTI 1.1 specification states in 6.1.1. that the score in replaceResult should
-                // always be formatted using “en” formatting
-                // (http://www.imsglobal.org/LTI/v1p1p1/ltiIMGv1p1p1.html#_Toc330273034).
 
                 var outcomeResponse = new ClientResponse();
                 try
                 {
                     client.DefaultRequestHeaders.Accept.Clear();
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    var xml = new StringBuilder();
-                    using (var writer = new StringWriter(xml))
-                    {
-                        ImsxRequestSerializer.Serialize(writer, imsxEnvelope);
-                        await writer.FlushAsync();
-                    }
-                    var httpContent = new StringContent(xml.ToString(), Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, httpContent, consumerKey, consumerSecret);
-                    using (var response = await client.PostAsync(serviceUrl, httpContent))
+
+                    // Create a UTF8 encoding of the request
+                    var xml = await GetXmlAsync(imsxEnvelope);
+                    var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret);
+
+                    // Post the request and check the response
+                    using (var response = await client.PostAsync(serviceUrl, xmlContent))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.IsSuccessStatusCode)
@@ -285,7 +283,7 @@ namespace LtiLibrary.NetCore.Clients
                                 : HttpStatusCode.BadRequest;
                         }
 #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync(new StringContent(xml.ToString(), Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType));
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync(new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType));
                         outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync();
 #endif
                     }
@@ -309,6 +307,30 @@ namespace LtiLibrary.NetCore.Clients
                     Exception = ex,
                     StatusCode = HttpStatusCode.InternalServerError
                 };
+            }
+        }
+
+        /// <summary>
+        /// Serialize the <see cref="imsx_POXEnvelopeType"/> into a <see cref="Encoding.UTF8"/> encoded string.
+        /// </summary>
+        /// <param name="imsxEnvelope"></param>
+        /// <returns></returns>
+        private static async Task<string> GetXmlAsync(imsx_POXEnvelopeType imsxEnvelope)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var writer =
+                    XmlWriter.Create(ms, new XmlWriterSettings
+                    {
+                        Async = true,
+                        Encoding = Encoding.UTF8,
+                        Indent = true
+                    }))
+                {
+                    ImsxRequestSerializer.Serialize(writer, imsxEnvelope);
+                    await writer.FlushAsync();
+                }
+                return Encoding.UTF8.GetString(ms.ToArray());
             }
         }
     }

--- a/LtiLibrary.NetCore/Clients/SecuredClient.cs
+++ b/LtiLibrary.NetCore/Clients/SecuredClient.cs
@@ -16,11 +16,35 @@ namespace LtiLibrary.NetCore.Clients
         internal static async Task SignRequest(HttpClient client, HttpMethod method, string serviceUrl,
             HttpContent content, string consumerKey, string consumerSecret)
         {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (string.IsNullOrEmpty(serviceUrl))
+            {
+                throw new ArgumentNullException(nameof(serviceUrl));
+            }
+
+            var serviceUri = new Uri(serviceUrl, UriKind.RelativeOrAbsolute);
+            if (!serviceUri.IsAbsoluteUri)
+            {
+                if (client.BaseAddress == null)
+                {
+                    throw new LtiException("If serviceUrl is relative, client.BaseAddress cannot be null.");
+                }
+
+                if (!Uri.TryCreate(client.BaseAddress, serviceUrl, out serviceUri))
+                {
+                    throw new LtiException($"Cannot form a valid URI from {client.BaseAddress} and {serviceUrl}.");
+                }
+            }
+            
             var ltiRequest = new LtiRequest(LtiConstants.LtiOauthBodyHashMessageType)
             {
                 ConsumerKey = consumerKey,
                 HttpMethod = method.Method,
-                Url = new Uri(client.BaseAddress, serviceUrl)
+                Url = serviceUri
             };
 
             AuthenticationHeaderValue authorizationHeader;

--- a/LtiLibrary.NetCore/Extensions/HttpExtensions.cs
+++ b/LtiLibrary.NetCore/Extensions/HttpExtensions.cs
@@ -23,10 +23,17 @@ namespace LtiLibrary.NetCore.Extensions
             {
                 sb.AppendFormat("{0}: {1}\n", header.Key, string.Join(",", header.Value ?? new string[] { }));
             }
-            if (content != null && content.Headers.ContentLength > 0)
+            if (content != null)
             {
-                sb.AppendLine();
-                sb.Append(await content.ReadAsStringAsync());
+                foreach (var header in content.Headers)
+                {
+                    sb.AppendFormat("{0}: {1}\n", header.Key, string.Join(",", header.Value ?? new string[] { }));
+                }
+                if (content.Headers.ContentLength > 0)
+                {
+                    sb.AppendLine();
+                    sb.Append(await content.ReadAsStringAsync());
+                }
             }
             return sb.ToString();
         }
@@ -44,10 +51,17 @@ namespace LtiLibrary.NetCore.Extensions
             {
                 sb.AppendFormat("{0}: {1}\n", header.Key, string.Join(",", header.Value ?? new string[] { }));
             }
-            if (response.Content != null && response.Content.Headers.ContentLength > 0)
+            if (response.Content != null)
             {
-                sb.AppendLine();
-                sb.Append(await response.Content.ReadAsStringAsync());
+                foreach (var header in response.Content.Headers)
+                {
+                    sb.AppendFormat("{0}: {1}\n", header.Key, string.Join(",", header.Value ?? new string[] { }));
+                }
+                if (response.Content.Headers.ContentLength > 0)
+                {
+                    sb.AppendLine();
+                    sb.Append(await response.Content.ReadAsStringAsync());
+                }
             }
             return sb.ToString();
         }

--- a/LtiLibrary.NetCore/Lis/v1/ContextType.cs
+++ b/LtiLibrary.NetCore/Lis/v1/ContextType.cs
@@ -11,19 +11,20 @@ namespace LtiLibrary.NetCore.Lis.v1
     public enum ContextType
     {
         /// <summary>
-        /// A course offering that might appear in a course catalog (e.g. ECON 101).
+        /// A course offering relates to the specific period of time when the course is available.
         /// </summary>
         [Urn("urn:lti:context-type:ims/lis/CourseOffering")]
         CourseOffering,
 
         /// <summary>
-        /// An instance of the course (e.g. Miss Marple's Home Room Class, or ECON 101 - Section 1).
+        /// A course section is the specific instance into which students are enrolled and taught.
         /// </summary>
         [Urn("urn:lti:context-type:ims/lis/CourseSection")]
         CourseSection,
 
         /// <summary>
-        /// The syllabus or curriculum for a course offering.
+        /// A course template is the abstract course which is independent of when it is taught.
+        /// The course template may have one or more course offerings, each of which may have one or more course sections.
         /// </summary>
         [Urn("urn:lti:context-type:ims/lis/CourseTemplate")]
         CourseTemplate,

--- a/LtiLibrary.NetCore/LtiLibrary.NetCore.csproj
+++ b/LtiLibrary.NetCore/LtiLibrary.NetCore.csproj
@@ -4,7 +4,7 @@
     <Description>.NET Core library with IMS LTI support for Tool Consumer and Tool Provider applications. Supports IMS LTI 1.0, 1.1, 1.1.1 and 1.2, Outcomes 1.0, Outcomes 2.0 (Draft), Content-Item Message 1.0, and Membership 1.0.</Description>
     <Copyright>Copyright 2017</Copyright>
     <AssemblyTitle>LtiLibrary.NetCore</AssemblyTitle>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <Authors>andyfmiller.com</Authors>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <AssemblyName>LtiLibrary.NetCore</AssemblyName>
@@ -12,6 +12,9 @@
     <PackageTags>IMS;LTI;.NET Core</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
+2.1.2
+- Fix a bug in Outcomes1Client that encoded request with utf-8 and xml with utf-16
+- Fix a bug in SecureClient that choked on null BaseAddress in the HttpClient
 2.1.1
 - Add support for liss and lism prefixes on Membership status and role.
 2.1.0


### PR DESCRIPTION
- Fix a bug in Outcomes1Client that encoded request with utf-8 and xml with utf-16
- Fix a bug in SecureClient that choked on null BaseAddress in the HttpClient
- Improve documentation