### PR TITLE
Fix for outcomes defect

### DIFF
--- a/src/LtiLibrary.AspNetCore/Common/AddBodyHashHeaderAttribute.cs
+++ b/src/LtiLibrary.AspNetCore/Common/AddBodyHashHeaderAttribute.cs
@@ -2,6 +2,7 @@
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Http.Internal;
 
 namespace LtiLibrary.AspNetCore.Common
 {
@@ -20,6 +21,8 @@ namespace LtiLibrary.AspNetCore.Common
         {
             var httpContext = context.HttpContext;
             var request = httpContext.Request;
+
+            request.EnableRewind();
 
             if (request.Body.CanRead)
             {

--- a/src/LtiLibrary.AspNetCore/Outcomes/v1/OutcomesControllerBase.cs
+++ b/src/LtiLibrary.AspNetCore/Outcomes/v1/OutcomesControllerBase.cs
@@ -222,6 +222,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
         private async Task<IActionResult> HandleReplaceResultRequest(imsx_RequestHeaderInfoType requestHeader, imsx_POXBodyType requestBody)
         {
             var replaceRequest = requestBody.Item as replaceResultRequest ?? new replaceResultRequest();
+            var replaceResponse = new replaceResultResponse();
 
             var result = GetResult(replaceRequest.resultRecord);
             try
@@ -231,7 +232,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
 
                 if (response.StatusCode == StatusCodes.Status200OK)
                 {
-                    return CreateSuccessResponse(replaceRequest, requestHeader.imsx_messageIdentifier,
+                    return CreateSuccessResponse(replaceResponse, requestHeader.imsx_messageIdentifier,
                         $"Score for {replaceRequest.resultRecord.sourcedGUID.sourcedId} is now {replaceRequest.resultRecord.result.resultScore.textString}");
                 }
                 return StatusCode(response.StatusCode);


### PR DESCRIPTION
Fixes #60

Uses an extension [helper method](https://github.com/aspnet/HttpAbstractions/blob/87cd79d6fc54bb4abf07c1e380cd7a9498a78612/src/Microsoft.AspNetCore.Http/Internal/BufferingHelper.cs#L41) to convert the stream into a type that can be reset back to the beginning after it's been read.

Alternatively, this problem could be solved by removing the [AddBodyHashHeader](https://github.com/andyfmiller/LtiLibrary/blob/master/src/LtiLibrary.AspNetCore/Outcomes/v1/OutcomesControllerBase.cs#L20) attribute from OutcomesControllerBase, but I don't know enough about how that hash value is used to know if removing that attribute is safe or not.