### PR TITLE
Implement a way to specify HMAC-SHA256. Implements #22

### DIFF
--- a/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
@@ -27,10 +27,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerSecret">The OAuth Consumer Secret to use for signing the request.</param>
         /// <param name="rlid">The ID of a resource link within the context and associated and the Tool Provider. The result set will be filtered so that it includes only those memberships that are permitted to access the resource link. If omitted, the result set will include all memberships for the context.</param>
         /// <param name="role">The role for a membership. The result set will be filtered so that it includes only those memberships that contain this role. The value of the parameter should be the full URI for the role, although the simple name may be used for context-level roles. If omitted, the result set will include all memberships with any role.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         public static async Task<ClientResponse<List<Membership>>> GetMembershipAsync(
             HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
-            string rlid = null, Role? role = null, string signatureMethod = null)
+            string rlid = null, Role? role = null, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             var filteredServiceUrl = GetFilteredServiceUrl(serviceUrl, null, rlid, role);
             var pageResponse = await GetFilteredMembershipPageAsync(client, filteredServiceUrl, consumerKey, consumerSecret, LtiConstants.LisMembershipContainerMediaType, signatureMethod);
@@ -90,10 +90,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="limit">Specifies the maximum number of items that should be delivered per page. This parameter is merely a hint. The server is not obligated to honor this limit and may at its own discretion choose a different value for the number of items per page.</param>
         /// <param name="rlid">The ID of a resource link within the context and associated and the Tool Provider. The result set will be filtered so that it includes only those memberships that are permitted to access the resource link. If omitted, the result set will include all memberships for the context.</param>
         /// <param name="role">The role for a membership. The result set will be filtered so that it includes only those memberships that contain this role. The value of the parameter should be the full URI for the role, although the simple name may be used for context-level roles. If omitted, the result set will include all memberships with any role.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         public static async Task<ClientResponse<MembershipContainerPage>> GetMembershipPageAsync(
             HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
-            int? limit = null, string rlid = null, Role? role = null, string signatureMethod = null)
+            int? limit = null, string rlid = null, Role? role = null, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             var filteredServiceUrl = GetFilteredServiceUrl(serviceUrl, limit, rlid, role);
             return await GetFilteredMembershipPageAsync(client, filteredServiceUrl, consumerKey, consumerSecret,
@@ -102,7 +102,7 @@ namespace LtiLibrary.NetCore.Clients
 
         private static async Task<ClientResponse<MembershipContainerPage>> GetFilteredMembershipPageAsync(
             HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
-            string contentType, string signatureMethod)
+            string contentType, SignatureMethod signatureMethod)
         {
             try
             {
@@ -110,7 +110,7 @@ namespace LtiLibrary.NetCore.Clients
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
 
                 await SecuredClient.SignRequest(client, HttpMethod.Get, serviceUrl, new StringContent(string.Empty), consumerKey,
-                    consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
+                    consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse<MembershipContainerPage>();
                 try

--- a/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
@@ -9,6 +9,7 @@ using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.Extensions;
 using LtiLibrary.NetCore.Lis.v1;
 using LtiLibrary.NetCore.Lis.v2;
+using LtiLibrary.NetCore.OAuth;
 
 namespace LtiLibrary.NetCore.Clients
 {
@@ -26,12 +27,13 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerSecret">The OAuth Consumer Secret to use for signing the request.</param>
         /// <param name="rlid">The ID of a resource link within the context and associated and the Tool Provider. The result set will be filtered so that it includes only those memberships that are permitted to access the resource link. If omitted, the result set will include all memberships for the context.</param>
         /// <param name="role">The role for a membership. The result set will be filtered so that it includes only those memberships that contain this role. The value of the parameter should be the full URI for the role, although the simple name may be used for context-level roles. If omitted, the result set will include all memberships with any role.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         public static async Task<ClientResponse<List<Membership>>> GetMembershipAsync(
             HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
-            string rlid = null, Role? role = null)
+            string rlid = null, Role? role = null, string signatureMethod = null)
         {
             var filteredServiceUrl = GetFilteredServiceUrl(serviceUrl, null, rlid, role);
-            var pageResponse = await GetFilteredMembershipPageAsync(client, filteredServiceUrl, consumerKey, consumerSecret, LtiConstants.LisMembershipContainerMediaType);
+            var pageResponse = await GetFilteredMembershipPageAsync(client, filteredServiceUrl, consumerKey, consumerSecret, LtiConstants.LisMembershipContainerMediaType, signatureMethod);
             Uri pageId = null;
             var result = new ClientResponse<List<Membership>>
             {
@@ -72,7 +74,7 @@ namespace LtiLibrary.NetCore.Clients
 
                 // Get the next page
                 filteredServiceUrl = GetFilteredServiceUrl(pageResponse.Response.NextPage, null, rlid, role);
-                pageResponse = await GetFilteredMembershipPageAsync(client, filteredServiceUrl, consumerKey, consumerSecret, LtiConstants.LisMembershipContainerMediaType);
+                pageResponse = await GetFilteredMembershipPageAsync(client, filteredServiceUrl, consumerKey, consumerSecret, LtiConstants.LisMembershipContainerMediaType, signatureMethod);
             } while (true);
 
             return result;
@@ -88,18 +90,19 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="limit">Specifies the maximum number of items that should be delivered per page. This parameter is merely a hint. The server is not obligated to honor this limit and may at its own discretion choose a different value for the number of items per page.</param>
         /// <param name="rlid">The ID of a resource link within the context and associated and the Tool Provider. The result set will be filtered so that it includes only those memberships that are permitted to access the resource link. If omitted, the result set will include all memberships for the context.</param>
         /// <param name="role">The role for a membership. The result set will be filtered so that it includes only those memberships that contain this role. The value of the parameter should be the full URI for the role, although the simple name may be used for context-level roles. If omitted, the result set will include all memberships with any role.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         public static async Task<ClientResponse<MembershipContainerPage>> GetMembershipPageAsync(
             HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
-            int? limit = null, string rlid = null, Role? role = null)
+            int? limit = null, string rlid = null, Role? role = null, string signatureMethod = null)
         {
             var filteredServiceUrl = GetFilteredServiceUrl(serviceUrl, limit, rlid, role);
             return await GetFilteredMembershipPageAsync(client, filteredServiceUrl, consumerKey, consumerSecret,
-                LtiConstants.LisMembershipContainerMediaType);
+                LtiConstants.LisMembershipContainerMediaType, signatureMethod);
         }
 
         private static async Task<ClientResponse<MembershipContainerPage>> GetFilteredMembershipPageAsync(
             HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
-            string contentType)
+            string contentType, string signatureMethod)
         {
             try
             {
@@ -107,7 +110,7 @@ namespace LtiLibrary.NetCore.Clients
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
 
                 await SecuredClient.SignRequest(client, HttpMethod.Get, serviceUrl, new StringContent(string.Empty), consumerKey,
-                    consumerSecret);
+                    consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
 
                 var outcomeResponse = new ClientResponse<MembershipContainerPage>();
                 try

--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -11,6 +11,7 @@ using System.Xml.Serialization;
 using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.Extensions;
 using LtiLibrary.NetCore.Lti.v1;
+using LtiLibrary.NetCore.OAuth;
 
 namespace LtiLibrary.NetCore.Clients
 {
@@ -45,8 +46,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth key to sign the request.</param>
         /// <param name="consumerSecret">The OAuth secret to sign the request.</param>
         /// <param name="sourcedId">The LisResultSourcedId to be deleted.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
-        public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, string sourcedId)
+        public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+            string sourcedId, string signatureMethod = null)
         {
             try
             {
@@ -75,7 +78,7 @@ namespace LtiLibrary.NetCore.Clients
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
 
                     // Post the request and check the response
                     using (var response = await client.PostAsync(serviceUrl, xmlContent))
@@ -127,8 +130,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth key to sign the request.</param>
         /// <param name="consumerSecret">The OAuth secret to sign the request.</param>
         /// <param name="lisResultSourcedId">The LisResult to read.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
-        public static async Task<ClientResponse<Result>> ReadResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId)
+        public static async Task<ClientResponse<Result>> ReadResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+            string lisResultSourcedId, string signatureMethod = null)
         {
             try
             {
@@ -157,7 +162,7 @@ namespace LtiLibrary.NetCore.Clients
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
 
                     // Post the request and check the response
                     using (var response = await client.PostAsync(serviceUrl, xmlContent))
@@ -225,8 +230,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerSecret">The OAuth secret to sign the request.</param>
         /// <param name="lisResultSourcedId">The LisResult to receive the score.</param>
         /// <param name="score">The score.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
-        public static async Task<ClientResponse> ReplaceResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, string lisResultSourcedId, double? score)
+        public static async Task<ClientResponse> ReplaceResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+            string lisResultSourcedId, double? score, string signatureMethod = null)
         {
             try
             {
@@ -266,7 +273,7 @@ namespace LtiLibrary.NetCore.Clients
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
 
                     // Post the request and check the response
                     using (var response = await client.PostAsync(serviceUrl, xmlContent))

--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -46,10 +46,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth key to sign the request.</param>
         /// <param name="consumerSecret">The OAuth secret to sign the request.</param>
         /// <param name="sourcedId">The LisResultSourcedId to be deleted.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
         public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
-            string sourcedId, string signatureMethod = null)
+            string sourcedId, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             try
             {
@@ -78,7 +78,7 @@ namespace LtiLibrary.NetCore.Clients
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod);
 
                     // Post the request and check the response
                     using (var response = await client.PostAsync(serviceUrl, xmlContent))
@@ -130,10 +130,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth key to sign the request.</param>
         /// <param name="consumerSecret">The OAuth secret to sign the request.</param>
         /// <param name="lisResultSourcedId">The LisResult to read.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
         public static async Task<ClientResponse<Result>> ReadResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
-            string lisResultSourcedId, string signatureMethod = null)
+            string lisResultSourcedId, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             try
             {
@@ -162,7 +162,7 @@ namespace LtiLibrary.NetCore.Clients
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod);
 
                     // Post the request and check the response
                     using (var response = await client.PostAsync(serviceUrl, xmlContent))
@@ -230,10 +230,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerSecret">The OAuth secret to sign the request.</param>
         /// <param name="lisResultSourcedId">The LisResult to receive the score.</param>
         /// <param name="score">The score.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
         public static async Task<ClientResponse> ReplaceResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
-            string lisResultSourcedId, double? score, string signatureMethod = null)
+            string lisResultSourcedId, double? score, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             try
             {
@@ -273,7 +273,7 @@ namespace LtiLibrary.NetCore.Clients
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod ?? OAuthConstants.SignatureMethodHmacSha1);
+                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod);
 
                     // Post the request and check the response
                     using (var response = await client.PostAsync(serviceUrl, xmlContent))

--- a/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
@@ -8,6 +8,7 @@ using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.Extensions;
 using LtiLibrary.NetCore.Lis.v2;
 using Result = LtiLibrary.NetCore.Lis.v2.Result;
+using LtiLibrary.NetCore.OAuth;
 
 namespace LtiLibrary.NetCore.Clients
 {
@@ -25,11 +26,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> DeleteLineItemAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret)
+            string consumerSecret, string signatureMethod = null)
         {
-            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret);
+            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod);
         }
 
         /// <summary>
@@ -39,11 +41,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> DeleteLineItemResultsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret)
+            string consumerSecret, string signatureMethod = null)
         {
-            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret);
+            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod);
         }
 
         /// <summary>
@@ -53,11 +56,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>If successful, the LineItem specified in the REST endpoint, but without the results property filled in.</returns>
         public static async Task<ClientResponse<LineItem>> GetLineItemAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret)
+            string consumerSecret, string signatureMethod = null)
         {
-            return await GetOutcomeAsync<LineItem>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemMediaType);
+            return await GetOutcomeAsync<LineItem>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -67,11 +71,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>If successful, the LineItem specified in the REST endpoint, including results.</returns>
         public static async Task<ClientResponse<LineItem>> GetLineItemWithResultsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret)
+            string consumerSecret, string signatureMethod = null)
         {
-            return await GetOutcomeAsync<LineItem>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemResultsMediaType);
+            return await GetOutcomeAsync<LineItem>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemResultsMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -85,12 +90,13 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="firstPage">True to request the first page of lineitems.</param>
         /// <param name="p">The page (2 to ?) of lineitems requested.</param>
         /// <param name="activityId">If specified, the result set will be filtered to only include lineitems that are associated with this activity.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>If successful, the LineItemContainerPage.</returns>
         public static async Task<ClientResponse<LineItemContainerPage>> GetLineItemsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null, string activityId = null)
+            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null, string activityId = null, string signatureMethod = null)
         {
             var servicePageUrl = GetPagingServiceUrl(serviceUrl, limit, firstPage, p, activityId);
-            return await GetOutcomeAsync<LineItemContainerPage>(client, servicePageUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemContainerMediaType);
+            return await GetOutcomeAsync<LineItemContainerPage>(client, servicePageUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemContainerMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -101,6 +107,7 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="lineItem">The LineItem to create within the server.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>If successful, the LineItem with @id and results filled in.</returns>
         /// <remarks>
         /// https://www.imsglobal.org/specs/ltiomv2p0/specification-3
@@ -111,9 +118,9 @@ namespace LtiLibrary.NetCore.Clients
         /// result may be a PUT or a GET request.
         /// </remarks>
         public static async Task<ClientResponse<LineItem>> PostLineItemAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, LineItem lineItem)
+            string consumerSecret, LineItem lineItem, string signatureMethod = null)
         {
-            return await PostOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType);
+            return await PostOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -124,10 +131,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="lineItem">The LineItem to be updated within the server.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>No content is returned.</returns>
-        public static async Task<ClientResponse> PutLineItemAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, LineItem lineItem)
+        public static async Task<ClientResponse> PutLineItemAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+            LineItem lineItem, string signatureMethod = null)
         {
-            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType);
+            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -138,10 +147,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="lineItem">The LineItem to be updated within the server.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>No content is returned.</returns>
-        public static async Task<ClientResponse> PutLineItemWithResultsAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, LineItem lineItem)
+        public static async Task<ClientResponse> PutLineItemWithResultsAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+            LineItem lineItem, string signatureMethod = null)
         {
-            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemResultsMediaType);
+            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemResultsMediaType, signatureMethod);
         }
 
         #endregion
@@ -155,11 +166,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LISResult REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret)
+            string consumerSecret, string signatureMethod = null)
         {
-            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret);
+            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod);
         }
 
         /// <summary>
@@ -169,11 +181,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LISResult REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>If successful, the LISResult specified in the REST endpoint.</returns>
         public static async Task<ClientResponse<Result>> GetResultAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret)
+            string consumerSecret, string signatureMethod = null)
         {
-            return await GetOutcomeAsync<Result>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisResultMediaType);
+            return await GetOutcomeAsync<Result>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisResultMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -186,12 +199,13 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="limit">The suggested number of results to include in each page.</param>
         /// <param name="firstPage">True to request the first page of results.</param>
         /// <param name="p">The page (2 to ?) of results requested.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>If successful, the ResultContainerPage.</returns>
         public static async Task<ClientResponse<ResultContainerPage>> GetResultsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null)
+            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null, string signatureMethod = null)
         {
             var servicePageUrl = GetPagingServiceUrl(serviceUrl, limit, firstPage, p);
-            return await GetOutcomeAsync<ResultContainerPage>(client, servicePageUrl, consumerKey, consumerSecret, LtiConstants.LisResultContainerMediaType);
+            return await GetOutcomeAsync<ResultContainerPage>(client, servicePageUrl, consumerKey, consumerSecret, LtiConstants.LisResultContainerMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -202,11 +216,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="result">The LISResult to create within the server.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>If successful, the LISResult with @id filled in.</returns>
         public static async Task<ClientResponse<Result>> PostResultAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, Result result)
+            string consumerSecret, Result result, string signatureMethod)
         {
-            return await PostOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType);
+            return await PostOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType, signatureMethod);
         }
 
         /// <summary>
@@ -217,10 +232,12 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="result">The LISResult to be updated within the server.</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
         /// <returns>No content is returned.</returns>
-        public static async Task<ClientResponse> PutResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, Result result)
+        public static async Task<ClientResponse> PutResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, Result result,
+            string signatureMethod)
         {
-            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType);
+            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType, signatureMethod);
         }
 
         #endregion
@@ -228,11 +245,11 @@ namespace LtiLibrary.NetCore.Clients
         #region Private Methods
 
         private static async Task<ClientResponse> DeleteOutcomeAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret)
+            string consumerSecret, string signatureMethod)
         {
             try
             {
-                await SecuredClient.SignRequest(client, HttpMethod.Delete, serviceUrl, new StringContent(string.Empty), consumerKey, consumerSecret);
+                await SecuredClient.SignRequest(client, HttpMethod.Delete, serviceUrl, new StringContent(string.Empty), consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse();
                 try
@@ -273,14 +290,14 @@ namespace LtiLibrary.NetCore.Clients
         }
 
         private static async Task<ClientResponse<T>> GetOutcomeAsync<T>(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string contentType) where T : class
+            string consumerSecret, string contentType, string signatureMethod) where T : class
         {
             try
             {
                 client.DefaultRequestHeaders.Accept.Clear();
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
 
-                await SecuredClient.SignRequest(client, HttpMethod.Get, serviceUrl, new StringContent(string.Empty), consumerKey, consumerSecret);
+                await SecuredClient.SignRequest(client, HttpMethod.Get, serviceUrl, new StringContent(string.Empty), consumerKey, consumerSecret, signatureMethod);
                 
                 var outcomeResponse = new ClientResponse<T>();
                 try
@@ -352,13 +369,13 @@ namespace LtiLibrary.NetCore.Clients
         }
 
         private static async Task<ClientResponse<T>> PostOutcomeAsync<T>(HttpClient client, string serviceUrl,
-            string consumerKey, string consumerSecret, T content, string contentType) where T : class
+            string consumerKey, string consumerSecret, T content, string contentType, string signatureMethod) where T : class
         {
             try
             {
                 var httpContent = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType);
 
-                await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, httpContent, consumerKey, consumerSecret);
+                await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, httpContent, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse<T>();
                 try
@@ -400,13 +417,13 @@ namespace LtiLibrary.NetCore.Clients
         }
 
         private static async Task<ClientResponse> PutOutcomeAsync<T>(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, T content, string contentType)
+            string consumerSecret, T content, string contentType, string signatureMethod)
         {
             try
             {
                 var httpContent = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType);
 
-                await SecuredClient.SignRequest(client, HttpMethod.Put, serviceUrl, httpContent, consumerKey, consumerSecret);
+                await SecuredClient.SignRequest(client, HttpMethod.Put, serviceUrl, httpContent, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse();
                 try

--- a/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
@@ -26,10 +26,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> DeleteLineItemAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string signatureMethod = null)
+            string consumerSecret, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod);
         }
@@ -41,10 +41,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> DeleteLineItemResultsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string signatureMethod = null)
+            string consumerSecret, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod);
         }
@@ -56,10 +56,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>If successful, the LineItem specified in the REST endpoint, but without the results property filled in.</returns>
         public static async Task<ClientResponse<LineItem>> GetLineItemAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string signatureMethod = null)
+            string consumerSecret, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await GetOutcomeAsync<LineItem>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemMediaType, signatureMethod);
         }
@@ -71,10 +71,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LineItem REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>If successful, the LineItem specified in the REST endpoint, including results.</returns>
         public static async Task<ClientResponse<LineItem>> GetLineItemWithResultsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string signatureMethod = null)
+            string consumerSecret, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await GetOutcomeAsync<LineItem>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemResultsMediaType, signatureMethod);
         }
@@ -90,10 +90,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="firstPage">True to request the first page of lineitems.</param>
         /// <param name="p">The page (2 to ?) of lineitems requested.</param>
         /// <param name="activityId">If specified, the result set will be filtered to only include lineitems that are associated with this activity.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>If successful, the LineItemContainerPage.</returns>
         public static async Task<ClientResponse<LineItemContainerPage>> GetLineItemsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null, string activityId = null, string signatureMethod = null)
+            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null, string activityId = null, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             var servicePageUrl = GetPagingServiceUrl(serviceUrl, limit, firstPage, p, activityId);
             return await GetOutcomeAsync<LineItemContainerPage>(client, servicePageUrl, consumerKey, consumerSecret, LtiConstants.LisLineItemContainerMediaType, signatureMethod);
@@ -107,7 +107,7 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="lineItem">The LineItem to create within the server.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>If successful, the LineItem with @id and results filled in.</returns>
         /// <remarks>
         /// https://www.imsglobal.org/specs/ltiomv2p0/specification-3
@@ -118,7 +118,7 @@ namespace LtiLibrary.NetCore.Clients
         /// result may be a PUT or a GET request.
         /// </remarks>
         public static async Task<ClientResponse<LineItem>> PostLineItemAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, LineItem lineItem, string signatureMethod = null)
+            string consumerSecret, LineItem lineItem, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await PostOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType, signatureMethod);
         }
@@ -131,10 +131,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="lineItem">The LineItem to be updated within the server.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> PutLineItemAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
-            LineItem lineItem, string signatureMethod = null)
+            LineItem lineItem, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType, signatureMethod);
         }
@@ -147,10 +147,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="lineItem">The LineItem to be updated within the server.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> PutLineItemWithResultsAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
-            LineItem lineItem, string signatureMethod = null)
+            LineItem lineItem, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemResultsMediaType, signatureMethod);
         }
@@ -166,10 +166,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LISResult REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string signatureMethod = null)
+            string consumerSecret, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod);
         }
@@ -181,10 +181,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="serviceUrl">The LISResult REST endpoint.</param>
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>If successful, the LISResult specified in the REST endpoint.</returns>
         public static async Task<ClientResponse<Result>> GetResultAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string signatureMethod = null)
+            string consumerSecret, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await GetOutcomeAsync<Result>(client, serviceUrl, consumerKey, consumerSecret, LtiConstants.LisResultMediaType, signatureMethod);
         }
@@ -199,10 +199,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="limit">The suggested number of results to include in each page.</param>
         /// <param name="firstPage">True to request the first page of results.</param>
         /// <param name="p">The page (2 to ?) of results requested.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>If successful, the ResultContainerPage.</returns>
         public static async Task<ClientResponse<ResultContainerPage>> GetResultsAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null, string signatureMethod = null)
+            string consumerSecret, int? limit = null, bool? firstPage = null, int? p = null, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             var servicePageUrl = GetPagingServiceUrl(serviceUrl, limit, firstPage, p);
             return await GetOutcomeAsync<ResultContainerPage>(client, servicePageUrl, consumerKey, consumerSecret, LtiConstants.LisResultContainerMediaType, signatureMethod);
@@ -216,10 +216,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="result">The LISResult to create within the server.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>If successful, the LISResult with @id filled in.</returns>
         public static async Task<ClientResponse<Result>> PostResultAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, Result result, string signatureMethod)
+            string consumerSecret, Result result, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await PostOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType, signatureMethod);
         }
@@ -232,10 +232,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="consumerKey">The OAuth consumer key to use to form the Authorization header.</param>
         /// <param name="consumerSecret">The OAuth consumer secret to use to form the Authorization header.</param>
         /// <param name="result">The LISResult to be updated within the server.</param>
-        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="OAuthConstants.SignatureMethodHmacSha1"/>, currently <see cref="OAuthConstants.SignatureMethodHmacSha256"/> is also available</param>
+        /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>No content is returned.</returns>
         public static async Task<ClientResponse> PutResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, Result result,
-            string signatureMethod)
+            SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType, signatureMethod);
         }
@@ -245,7 +245,7 @@ namespace LtiLibrary.NetCore.Clients
         #region Private Methods
 
         private static async Task<ClientResponse> DeleteOutcomeAsync(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string signatureMethod)
+            string consumerSecret, SignatureMethod signatureMethod)
         {
             try
             {
@@ -290,7 +290,7 @@ namespace LtiLibrary.NetCore.Clients
         }
 
         private static async Task<ClientResponse<T>> GetOutcomeAsync<T>(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, string contentType, string signatureMethod) where T : class
+            string consumerSecret, string contentType, SignatureMethod signatureMethod) where T : class
         {
             try
             {
@@ -369,7 +369,7 @@ namespace LtiLibrary.NetCore.Clients
         }
 
         private static async Task<ClientResponse<T>> PostOutcomeAsync<T>(HttpClient client, string serviceUrl,
-            string consumerKey, string consumerSecret, T content, string contentType, string signatureMethod) where T : class
+            string consumerKey, string consumerSecret, T content, string contentType, SignatureMethod signatureMethod) where T : class
         {
             try
             {
@@ -417,7 +417,7 @@ namespace LtiLibrary.NetCore.Clients
         }
 
         private static async Task<ClientResponse> PutOutcomeAsync<T>(HttpClient client, string serviceUrl, string consumerKey,
-            string consumerSecret, T content, string contentType, string signatureMethod)
+            string consumerSecret, T content, string contentType, SignatureMethod signatureMethod)
         {
             try
             {

--- a/src/LtiLibrary.NetCore/Clients/SecuredClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/SecuredClient.cs
@@ -15,7 +15,7 @@ namespace LtiLibrary.NetCore.Clients
     internal static class SecuredClient
     {
         internal static async Task SignRequest(HttpClient client, HttpMethod method, string serviceUrl,
-            HttpContent content, string consumerKey, string consumerSecret, string signatureMethod)
+            HttpContent content, string consumerKey, string consumerSecret, SignatureMethod signatureMethod)
         {
             if (client == null)
             {
@@ -54,11 +54,18 @@ namespace LtiLibrary.NetCore.Clients
             HashAlgorithm sha;
             switch(signatureMethod)
             {
-                case OAuthConstants.SignatureMethodHmacSha256:
+                default:
+                case SignatureMethod.HmacSha1:
+                    sha = SHA1.Create();
+                    break;
+                case SignatureMethod.HmacSha256:
                     sha = SHA256.Create();
                     break;
-                default:
-                    sha = SHA1.Create();
+                case SignatureMethod.HmacSha384:
+                    sha = SHA384.Create();
+                    break;
+                case SignatureMethod.HmacSha512:
+                    sha = SHA512.Create();
                     break;
             }
 

--- a/src/LtiLibrary.NetCore/Clients/SecuredClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/SecuredClient.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.Lti.v1;
+using LtiLibrary.NetCore.OAuth;
 
 namespace LtiLibrary.NetCore.Clients
 {
@@ -14,7 +15,7 @@ namespace LtiLibrary.NetCore.Clients
     internal static class SecuredClient
     {
         internal static async Task SignRequest(HttpClient client, HttpMethod method, string serviceUrl,
-            HttpContent content, string consumerKey, string consumerSecret)
+            HttpContent content, string consumerKey, string consumerSecret, string signatureMethod)
         {
             if (client == null)
             {
@@ -49,10 +50,22 @@ namespace LtiLibrary.NetCore.Clients
 
             AuthenticationHeaderValue authorizationHeader;
 
-            // Create an Authorization header using the body hash
-            using (var sha1 = SHA1.Create())
+            // Determine hashing algorithm
+            HashAlgorithm sha;
+            switch(signatureMethod)
             {
-                var hash = sha1.ComputeHash(await content.ReadAsByteArrayAsync());
+                case OAuthConstants.SignatureMethodHmacSha256:
+                    sha = SHA256.Create();
+                    break;
+                default:
+                    sha = SHA1.Create();
+                    break;
+            }
+
+            // Create an Authorization header using the body hash
+            using (sha)
+            {
+                var hash = sha.ComputeHash(await content.ReadAsByteArrayAsync());
                 authorizationHeader = ltiRequest.GenerateAuthorizationHeader(hash, consumerSecret);
             }
 

--- a/src/LtiLibrary.NetCore/OAuth/OAuthConstants.cs
+++ b/src/LtiLibrary.NetCore/OAuth/OAuthConstants.cs
@@ -68,6 +68,11 @@ namespace LtiLibrary.NetCore.OAuth
         public const string SignatureMethodHmacSha1 = "HMAC-SHA1";
 
         /// <summary>
+        /// HMAC-SHA1 signature method.
+        /// </summary>
+        public const string SignatureMethodHmacSha256 = "HMAC-SHA256";
+
+        /// <summary>
         /// oauth_timestamp parameter name.
         /// </summary>
         public const string TimestampParameter = "oauth_timestamp";

--- a/src/LtiLibrary.NetCore/OAuth/OAuthConstants.cs
+++ b/src/LtiLibrary.NetCore/OAuth/OAuthConstants.cs
@@ -68,9 +68,19 @@ namespace LtiLibrary.NetCore.OAuth
         public const string SignatureMethodHmacSha1 = "HMAC-SHA1";
 
         /// <summary>
-        /// HMAC-SHA1 signature method.
+        /// HMAC-SHA256 signature method.
         /// </summary>
         public const string SignatureMethodHmacSha256 = "HMAC-SHA256";
+
+        /// <summary>
+        /// HMAC-SHA384 signature method.
+        /// </summary>
+        public const string SignatureMethodHmacSha384 = "HMAC-SHA384";
+
+        /// <summary>
+        /// HMAC-SHA512 signature method.
+        /// </summary>
+        public const string SignatureMethodHmacSha512 = "HMAC-SHA512";
 
         /// <summary>
         /// oauth_timestamp parameter name.

--- a/src/LtiLibrary.NetCore/OAuth/OAuthRequest.cs
+++ b/src/LtiLibrary.NetCore/OAuth/OAuthRequest.cs
@@ -352,6 +352,12 @@ namespace LtiLibrary.NetCore.OAuth
             HMAC hmac;
             switch (parameters[OAuthConstants.SignatureMethodParameter])
             {
+                case OAuthConstants.SignatureMethodHmacSha512:
+                    hmac = new HMACSHA512 { Key = key };
+                    break;
+                case OAuthConstants.SignatureMethodHmacSha384:
+                    hmac = new HMACSHA384 { Key = key };
+                    break;
                 case OAuthConstants.SignatureMethodHmacSha256:
                     hmac = new HMACSHA256 { Key = key };
                     break;

--- a/src/LtiLibrary.NetCore/OAuth/OAuthRequest.cs
+++ b/src/LtiLibrary.NetCore/OAuth/OAuthRequest.cs
@@ -347,13 +347,21 @@ namespace LtiLibrary.NetCore.OAuth
             var signatureBase = GenerateSignatureBase(httpMethod, url, parameters);
 
             // Note that in LTI, the TokenSecret (second part of the key) is blank
-            var hmacsha1 = new HMACSHA1
+            var key = Encoding.ASCII.GetBytes($"{consumerSecret.ToRfc3986EncodedString()}&");
+
+            HMAC hmac;
+            switch (parameters[OAuthConstants.SignatureMethodParameter])
             {
-                Key = Encoding.ASCII.GetBytes($"{consumerSecret.ToRfc3986EncodedString()}&")
-            };
+                case OAuthConstants.SignatureMethodHmacSha256:
+                    hmac = new HMACSHA256 { Key = key };
+                    break;
+                default:
+                    hmac = new HMACSHA1 { Key = key };
+                    break;
+            }
 
             var dataBuffer = Encoding.ASCII.GetBytes(signatureBase);
-            var hashBytes = hmacsha1.ComputeHash(dataBuffer);
+            var hashBytes = hmac.ComputeHash(dataBuffer);
 
             return Convert.ToBase64String(hashBytes);
         }

--- a/src/LtiLibrary.NetCore/OAuth/SignatureMethod.cs
+++ b/src/LtiLibrary.NetCore/OAuth/SignatureMethod.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LtiLibrary.NetCore.OAuth
+{
+    public enum SignatureMethod
+    {
+        HmacSha1,
+        HmacSha256,
+        HmacSha384,
+        HmacSha512,
+    }
+}

--- a/test/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
+++ b/test/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
@@ -194,8 +194,12 @@ namespace LtiLibrary.NetCore.Tests
             Assert.Equal($"Missing parameter(s): {LtiConstants.ContentItemPlacementParameter}.", ex.Message);
         }
 
-        [Fact]
-        public void GenerateKnownSignature_GivenKnownLaunchParameters()
+        [Theory]
+        [InlineData("HMAC-SHA1", "Im/RhYIEApfbsy+luuisvQqBjgs=")]
+        [InlineData("HMAC-SHA256", "qQbfvgDf7WK/6+6XYCKlpu8klUMjH28NBk/U/CGOGEg=")]
+        [InlineData("HMAC-SHA384", "FPZNr6ekXPwAI+B8N4Qvazgkq5mK7qnBvzRc52z/FxRfJA+hKggE2LBCqGVnkRud")]
+        [InlineData("HMAC-SHA512", "ukswtvxdFC7RCVcmtxt/kvg6oE1v3zAJhtuNLRUnM3fjXIxMkg85uEq6Vz+fxLCEQ/YTPM9aBnsmEizyv3LxtQ==")]
+        public void GenerateKnownSignature_GivenKnownLaunchParameters(string signatureMethod, string expectedSignature)
         {
             var request = new LtiRequest
             {
@@ -214,7 +218,7 @@ namespace LtiLibrary.NetCore.Tests
                 ResourceLinkId = "3280",
                 ResourceLinkTitle = "docker",
                 Roles = "Instructor,Learner",
-                SignatureMethod = "HMAC-SHA1",
+                SignatureMethod = signatureMethod,
                 Timestamp = 1492745602,
                 ToolConsumerInfoProductFamilyCode = "Consumer",
                 ToolConsumerInfoVersion = "1.5.0.0",
@@ -225,11 +229,15 @@ namespace LtiLibrary.NetCore.Tests
                 Version = "1.0"
             };
             var signature = request.GenerateSignature("secret");
-            Assert.Equal("Im/RhYIEApfbsy+luuisvQqBjgs=", signature);
+            Assert.Equal(expectedSignature, signature);
         }
 
-        [Fact]
-        public void GenerateKnownSignature_GivenKnownOutcomesParameters()
+        [Theory]
+        [InlineData("HMAC-SHA1", "1lsA7F7WPN48KzxVXDI25Lpam1E=")]
+        [InlineData("HMAC-SHA256", "4KGg3xbB7Ke1FpIpQIEDvUuq5i2+PL+nFhU4BwM/jNw=")]
+        [InlineData("HMAC-SHA384", "4qMYDlaEmS+c7SIXFHiJcuXsVgdKhtLS1pANiTCvHiWQK3m2aTG2fq9FNuAHZWbt")]
+        [InlineData("HMAC-SHA512", "kh1W81jm0S2PnWH5DA73lYjJVe93EwfzDcnqiNim6kylvj67tnWPvSdm8R/zBsRZ7aZZxAyvZSSFKQwnlCBljA==")]
+        public void GenerateKnownSignature_GivenKnownOutcomesParameters(string signatureMethod, string expectedSignature)
         {
             var request = new LtiRequest
             {
@@ -237,13 +245,13 @@ namespace LtiLibrary.NetCore.Tests
                 ConsumerKey = "jisc.ac.uk",
                 HttpMethod = HttpMethod.Post.Method,
                 Nonce = "83e29bff47b7690a3f6b371c77526405",
-                SignatureMethod = "HMAC-SHA1",
+                SignatureMethod = signatureMethod,
                 Timestamp = 1493164209,
                 Url = new Uri("http://lti.tools/test/tc-outcomes.php"),
                 Version = "1.0"
             };
             var signature = request.GenerateSignature("secret");
-            Assert.Equal("1lsA7F7WPN48KzxVXDI25Lpam1E=", signature);
+            Assert.Equal(expectedSignature, signature);
         }
     }
 }


### PR DESCRIPTION
Implement a way for users of the library to use HMAC-SHA256 instead of the default HMAC-SHA1. Please comment/suggest if this is a workable solution.