### PR TITLE
Remove utf8 byte order mark

### DIFF
--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -347,7 +347,7 @@ namespace LtiLibrary.NetCore.Clients
                     XmlWriter.Create(ms, new XmlWriterSettings
                     {
                         Async = true,
-                        Encoding = Encoding.UTF8,
+                        Encoding = new UTF8Encoding(false),
                         Indent = true
                     }))
                 {


### PR DESCRIPTION
Thanks a lot for providing this great library! My team had an issue today where requests made through postman and fiddler were mysteriously failing, despite being seemingly identical to successful requests made programmatically. On deeper analysis through a hex editor, we found that the programmatically generated request included a UTF-8 byte order mark. This PR configures the XmlWriter to no longer emit a byte order mark.