### PR TITLE
Fix for #80 - test cases fail when current locale is nl-NL

### DIFF
--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -192,7 +192,10 @@ namespace LtiLibrary.NetCore.Clients
                                 }
                                 else
                                 {
-                                    outcomeResponse.Response = double.TryParse(imsxResponseBody.result.resultScore.textString, out var result) 
+                                    // The TC is supposed to use "en" language format, but this allows
+                                    // a little bit of misbehaving.
+                                    var cultureInfo = new CultureInfo(imsxResponseBody.result.resultScore.language??"en");
+                                    outcomeResponse.Response = double.TryParse(imsxResponseBody.result.resultScore.textString, NumberStyles.Number, cultureInfo, out var result) 
                                         ? new Result { Score = result, SourcedId = lisResultSourcedId } 
                                         : new Result { Score = null, SourcedId = lisResultSourcedId };
                                 }

--- a/test/LtiLibrary.AspNetCore.Tests/Outcomes/v1/OutcomesControllerShould.cs
+++ b/test/LtiLibrary.AspNetCore.Tests/Outcomes/v1/OutcomesControllerShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -31,21 +32,49 @@ namespace LtiLibrary.AspNetCore.Tests.Outcomes.v1
         }
 
         [Fact]
-        public async void ReplaceResult()
+        public async void ReplaceResult_WhenCultureIsEN()
         {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-EN");
             var replaceResult = await Outcomes1Client.ReplaceResultAsync(_client, Url, Key, Secret, Id, Value);
-            Assert.True(replaceResult.StatusCode == HttpStatusCode.OK, $"{replaceResult.StatusCode} == {HttpStatusCode.OK}");
+            Assert.Equal(HttpStatusCode.OK, replaceResult.StatusCode);
+
+            var start = replaceResult.HttpResponse.IndexOf("<imsx_description>", StringComparison.Ordinal) + "<imsx_description>".Length;
+            var end = replaceResult.HttpResponse.IndexOf("</imsx_description>", StringComparison.Ordinal);
+            Assert.Equal("Score for testId is now 0.5", replaceResult.HttpResponse.Substring(start, end-start));
         }
 
         [Fact]
-        public async void ReadResult()
+        public async void ReplaceResult_WhenCultureIsNL()
         {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("nl-NL");
+            var replaceResult = await Outcomes1Client.ReplaceResultAsync(_client, Url, Key, Secret, Id, Value);
+            Assert.Equal(HttpStatusCode.OK, replaceResult.StatusCode);
+
+            var start = replaceResult.HttpResponse.IndexOf("<imsx_description>", StringComparison.Ordinal) + "<imsx_description>".Length;
+            var end = replaceResult.HttpResponse.IndexOf("</imsx_description>", StringComparison.Ordinal);
+            Assert.Equal("Score for testId is now 0.5", replaceResult.HttpResponse.Substring(start, end - start));
+        }
+
+        [Fact]
+        public async void ReadResult_WhenCultureIsEN()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-EN");
             await Outcomes1Client.ReplaceResultAsync(_client, Url, Key, Secret, Id, Value);
             var readResult = await Outcomes1Client.ReadResultAsync(_client, Url, Key, Secret, Id);
             Assert.True(readResult.StatusCode == HttpStatusCode.OK, $"{readResult.StatusCode} == {HttpStatusCode.OK}");
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            Assert.True(readResult.Response.Score == Value, $"{readResult.Response.Score} == {Value}");
-            Assert.True(readResult.Response.SourcedId == Id, $"{readResult.Response.SourcedId} == {Id}");
+            Assert.Equal(Value, readResult.Response.Score);
+        }
+
+        [Fact]
+        public async void ReadResult_WhenCultureIsNL()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("nl-NL");
+            await Outcomes1Client.ReplaceResultAsync(_client, Url, Key, Secret, Id, Value);
+            var readResult = await Outcomes1Client.ReadResultAsync(_client, Url, Key, Secret, Id);
+            Assert.True(readResult.StatusCode == HttpStatusCode.OK, $"{readResult.StatusCode} == {HttpStatusCode.OK}");
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            Assert.Equal(Value, readResult.Response.Score);
         }
 
         [Fact]

--- a/test/LtiLibrary.AspNetCore.Tests/ReferenceJson/ContentItemSelectionRequest.json
+++ b/test/LtiLibrary.AspNetCore.Tests/ReferenceJson/ContentItemSelectionRequest.json
@@ -4,7 +4,7 @@
   "oauth_consumer_key": "12345",
   "oauth_signature_method": "HMAC-SHA1",
   "oauth_version": "1.0",
-  "launch_presentation_locale": "en-US",
+  "launch_presentation_locale": "{lcid}",
   "lti_version": "LTI-1p0",
   "resource_link_id": "launch",
   "accept_media_types": "text/html,image/*",

--- a/test/LtiLibrary.AspNetCore.Tests/ReferenceJson/basic-lti-launch-request.json
+++ b/test/LtiLibrary.AspNetCore.Tests/ReferenceJson/basic-lti-launch-request.json
@@ -9,7 +9,7 @@
   "context_id": "course-1",
   "context_title": "Course 1",
   "context_type": "CourseSection",
-  "launch_presentation_locale": "en-US",
+  "launch_presentation_locale": "{lcid}",
   "lis_person_contact_email_primary": "jdoe@andyfmiller.com",
   "lis_person_name_family": "Doe",
   "lis_person_name_given": "Joan",

--- a/test/LtiLibrary.AspNetCore.Tests/SimpleHelpers/JsonAssertions.cs
+++ b/test/LtiLibrary.AspNetCore.Tests/SimpleHelpers/JsonAssertions.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using LtiLibrary.NetCore.Common;
+﻿using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.Extensions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -9,46 +8,40 @@ using Xunit;
 
 namespace LtiLibrary.AspNetCore.Tests.SimpleHelpers
 {
-        internal static class JsonAssertions
+    internal static class JsonAssertions
+    {
+        private static readonly JsonSerializerSettings SerializerSettings;
+
+        static JsonAssertions()
         {
-            private static readonly JsonSerializerSettings SerializerSettings;
-
-            static JsonAssertions()
-            {
-                SerializerSettings = new JsonSerializerSettings();
-                SerializerSettings.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
-            }
-
-            public static void AssertSameObjectJson(object obj, string eventReferenceFile)
-            {
-                var eventJsonString = JsonConvert.SerializeObject(obj, SerializerSettings);
-                var eventJObject = JObject.Parse(eventJsonString);
-                var refJsonString = TestUtils.LoadReferenceJsonFile(eventReferenceFile);
-                var refJObject = JObject.Parse(refJsonString);
-
-                var diff = ObjectDiffPatch.GenerateDiff(refJObject, eventJObject);
-
-                Debug.WriteLine(diff.NewValues);
-                Debug.WriteLine(diff.OldValues);
-
-                Assert.True(diff.NewValues == null, diff.NewValues?.ToString());
-                Assert.True(diff.OldValues == null, diff.NewValues?.ToString());
-            }
-
-        public static void AssertSameJsonLdObject( JsonLdObject obj, string eventReferenceFile )
-            {
-               var eventJsonString = obj.ToJsonLdString();
-               var eventJObject = JObject.Parse( eventJsonString );
-               var refJsonString = TestUtils.LoadReferenceJsonFile( eventReferenceFile );
-               var refJObject = JObject.Parse( refJsonString );
-
-               var diff = ObjectDiffPatch.GenerateDiff( refJObject, eventJObject );
-
-               Debug.WriteLine( diff.NewValues );
-               Debug.WriteLine( diff.OldValues );
-
-               Assert.Null( diff.NewValues );
-               Assert.Null( diff.OldValues );
-            }
+            SerializerSettings = new JsonSerializerSettings();
+            SerializerSettings.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
         }
+
+        public static void AssertSameObjectJson(object actualObject, string expectedJsonFile)
+        {
+            var actualJsonString = JsonConvert.SerializeObject(actualObject, SerializerSettings);
+            var actualJObject = JObject.Parse(actualJsonString);
+            var expectedJsonString = TestUtils.LoadReferenceJsonFile(expectedJsonFile);
+            var expectedJObject = JObject.Parse(expectedJsonString);
+
+            AssertSameObjectJson(expectedJObject, actualJObject);
+        }
+
+        public static void AssertSameJsonLdObject(JsonLdObject actualJsonLdObject, string expectedJsonFile)
+        {
+            var actualJsonString = actualJsonLdObject.ToJsonLdString();
+            var actualJObject = JObject.Parse(actualJsonString);
+            var expectedJsonString = TestUtils.LoadReferenceJsonFile(expectedJsonFile);
+            var expectedJObject = JObject.Parse(expectedJsonString);
+
+            AssertSameObjectJson(expectedJObject, actualJObject);
+        }
+
+        internal static void AssertSameObjectJson(JObject expected, JObject actual)
+        {
+            var diff = ObjectDiffPatch.GenerateDiff(expected, actual);
+            Assert.True(diff.NewValues == null && diff.OldValues == null, "Expected:\n" + diff.OldValues + "\nActual:\n" + diff.NewValues);
+        }
+    }
 }

--- a/test/LtiLibrary.NetCore.Tests/SimpleHelpers/JsonAssertions.cs
+++ b/test/LtiLibrary.NetCore.Tests/SimpleHelpers/JsonAssertions.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using LtiLibrary.NetCore.Common;
+﻿using LtiLibrary.NetCore.Common;
 using LtiLibrary.NetCore.Extensions;
 using LtiLibrary.NetCore.Tests.TestHelpers;
 using Newtonsoft.Json;
@@ -10,46 +9,40 @@ using Xunit;
 
 namespace LtiLibrary.NetCore.Tests.SimpleHelpers
 {
-        internal static class JsonAssertions
+    internal static class JsonAssertions
+    {
+        private static readonly JsonSerializerSettings SerializerSettings;
+
+        static JsonAssertions()
         {
-            private static readonly JsonSerializerSettings SerializerSettings;
-
-            static JsonAssertions()
-            {
-                SerializerSettings = new JsonSerializerSettings();
-                SerializerSettings.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
-            }
-
-            public static void AssertSameObjectJson(object obj, string eventReferenceFile)
-            {
-                var eventJsonString = JsonConvert.SerializeObject(obj, SerializerSettings);
-                var eventJObject = JObject.Parse(eventJsonString);
-                var refJsonString = TestUtils.LoadReferenceJsonFile(eventReferenceFile);
-                var refJObject = JObject.Parse(refJsonString);
-
-                var diff = ObjectDiffPatch.GenerateDiff(refJObject, eventJObject);
-
-                Debug.WriteLine(diff.NewValues);
-                Debug.WriteLine(diff.OldValues);
-
-                Assert.Null(diff.NewValues);
-                Assert.Null(diff.OldValues);
-            }
-
-            public static void AssertSameJsonLdObject( JsonLdObject obj, string eventReferenceFile )
-            {
-               var eventJsonString = obj.ToJsonLdString();
-               var eventJObject = JObject.Parse( eventJsonString );
-               var refJsonString = TestUtils.LoadReferenceJsonFile( eventReferenceFile );
-               var refJObject = JObject.Parse( refJsonString );
-
-               var diff = ObjectDiffPatch.GenerateDiff( refJObject, eventJObject );
-
-               Debug.WriteLine( diff.NewValues );
-               Debug.WriteLine( diff.OldValues );
-
-               Assert.Null( diff.NewValues );
-               Assert.Null( diff.OldValues );
-            }
+            SerializerSettings = new JsonSerializerSettings();
+            SerializerSettings.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
         }
+
+        public static void AssertSameObjectJson(object actualObject, string expectedJsonFile)
+        {
+            var actualJsonString = JsonConvert.SerializeObject(actualObject, SerializerSettings);
+            var actualJObject = JObject.Parse(actualJsonString);
+            var expectedJsonString = TestUtils.LoadReferenceJsonFile(expectedJsonFile);
+            var expectedJObject = JObject.Parse(expectedJsonString);
+
+            AssertSameObjectJson(expectedJObject, actualJObject);
+        }
+
+        public static void AssertSameJsonLdObject(JsonLdObject actualJsonLdObject, string expectedJsonFile)
+        {
+            var actualJsonString = actualJsonLdObject.ToJsonLdString();
+            var actualJObject = JObject.Parse(actualJsonString);
+            var expectedJsonString = TestUtils.LoadReferenceJsonFile(expectedJsonFile);
+            var expectedJObject = JObject.Parse(expectedJsonString);
+
+            AssertSameObjectJson(expectedJObject, actualJObject);
+        }
+
+        internal static void AssertSameObjectJson(JObject expected, JObject actual)
+        {
+            var diff = ObjectDiffPatch.GenerateDiff(expected, actual);
+            Assert.True(diff.NewValues == null && diff.OldValues == null, "Expected:\n" + diff.OldValues + "\nActual:\n" + diff.NewValues);
+        }
+    }
 }


### PR DESCRIPTION
- Fixed bug in Outcomes1Client.
- Updated affected test cases to test multiple locales.