### PR TITLE
Fixes #87 - NameValueCollection.ToNormalizedString() does not return expected result

### DIFF
--- a/src/LtiLibrary.NetCore/Extensions/NameValueCollectionExtensions.cs
+++ b/src/LtiLibrary.NetCore/Extensions/NameValueCollectionExtensions.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Globalization;
 using System.Text;
-using LtiLibrary.NetCore.Lis.v1;
-using LtiLibrary.NetCore.Lti.v1;
 using LtiLibrary.NetCore.OAuth;
 
 namespace LtiLibrary.NetCore.Extensions
@@ -14,87 +11,6 @@ namespace LtiLibrary.NetCore.Extensions
     /// </summary>
     public static class NameValueCollectionExtensions
     {
-        /// <summary>
-        /// Add a list of <see cref="Enum"/> values as a comma separated string.
-        /// </summary>
-        /// <param name="parameters">The <see cref="NameValueCollection"/>.</param>
-        /// <param name="name">The key of the entry to add.</param>
-        /// <param name="values">The list of <see cref="Enum"/> values to add.</param>
-        public static void AddParameter(this NameValueCollection parameters, string name, IList<Enum> values)
-        {
-            if (values.Count > 0)
-            {
-                parameters.Add(name, string.Join(",", values));
-            }
-        }
-
-        /// <summary>
-        /// Add an <see cref="int"/> value if it is not null.
-        /// </summary>
-        /// <param name="parameters">The <see cref="NameValueCollection"/>.</param>
-        /// <param name="name">The key of the entry to add.</param>
-        /// <param name="value">The nullable <see cref="int"/> value to add.</param>
-        public static void AddParameter(this NameValueCollection parameters, string name, int? value)
-        {
-            if (value.HasValue)
-            {
-                parameters.Add(name, value.Value.ToString(CultureInfo.InvariantCulture));
-            }
-        }
-
-        /// <summary>
-        /// Add an <see cref="long"/> value if it is not null.
-        /// </summary>
-        /// <param name="parameters">The <see cref="NameValueCollection"/>.</param>
-        /// <param name="name">The key of the entry to add.</param>
-        /// <param name="value">The nullable <see cref="long"/> value to add.</param>
-        public static void AddParameter(this NameValueCollection parameters, string name, long value)
-        {
-            parameters.Add(name, value.ToString(CultureInfo.InvariantCulture));
-        }
-
-        /// <summary>
-        /// Add a <see cref="DocumentTarget"/> value if it is not null.
-        /// </summary>
-        /// <param name="parameters">The <see cref="NameValueCollection"/>.</param>
-        /// <param name="name">The key of the entry to add.</param>
-        /// <param name="value">The nullable <see cref="DocumentTarget"/> value to add.</param>
-        public static void AddParameter(this NameValueCollection parameters, string name, DocumentTarget? value)
-        {
-            if (value.HasValue)
-            {
-                parameters.Add(name, value.Value.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Add a <see cref="ContextType"/> value if it is not null.
-        /// </summary>
-        /// <param name="parameters">The <see cref="NameValueCollection"/>.</param>
-        /// <param name="name">The key of the entry to add.</param>
-        /// <param name="value">The nullable <see cref="ContextType"/> value to add.</param>
-        public static void AddParameter(this NameValueCollection parameters, string name, ContextType? value)
-        {
-            if (value.HasValue)
-            {
-                parameters.Add(name, value.Value.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Add a <see cref="string"/> value if it is not null or whitespace.
-        /// </summary>
-        /// <param name="parameters">The <see cref="NameValueCollection"/>.</param>
-        /// <param name="name">The key of the entry to add.</param>
-        /// <param name="value">The <see cref="string"/> value to add.</param>
-        public static void AddParameter(this NameValueCollection parameters, string name, string value)
-        {
-            if (!string.IsNullOrWhiteSpace(value))
-            {
-                parameters.Add(name, value);
-            }
-        }
-
         /// <summary>
         /// Return a normalized string of parameters suitable for OAuth 1.0 signature base string
         /// as defined by https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
@@ -108,13 +24,16 @@ namespace LtiLibrary.NetCore.Extensions
             // https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1
             // Exclude the OAuth signature or realm in the signature base string
             var list = new List<KeyValuePair<string, string>>();
-            var excludedNames = new List<string> {OAuthConstants.SignatureParameter, OAuthConstants.RealmParameter};
+            var excludedNames = new List<string> { OAuthConstants.SignatureParameter, OAuthConstants.RealmParameter };
             foreach (var key in collection.AllKeys)
             {
                 if (excludedNames.Contains(key)) continue;
-                var value = collection[key] ?? string.Empty;
-                list.Add(new KeyValuePair<string, string>(key.ToRfc3986EncodedString(),
-                    value.ToRfc3986EncodedString()));
+                var values = collection.GetValues(key);
+                foreach (var value in values)
+                {
+                    list.Add(new KeyValuePair<string, string>(key.ToRfc3986EncodedString(),
+                        value.ToRfc3986EncodedString()));
+                }
             }
 
             // https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2

--- a/test/LtiLibrary.NetCore.Tests/NameValueCollectionShould.cs
+++ b/test/LtiLibrary.NetCore.Tests/NameValueCollectionShould.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Specialized;
+using LtiLibrary.NetCore.Extensions;
+using LtiLibrary.NetCore.OAuth;
+using Xunit;
+
+namespace LtiLibrary.NetCore.Tests
+{
+    public class NameValueCollectionShould
+    {
+        private readonly NameValueCollection _collection;
+
+        private readonly string _expected;
+
+        /// <summary>
+        /// A NameValueCollection is used to collect LTI request parameters
+        /// and ToNormalizedString is used convert that parameters into
+        /// a normalized string for the purpose of constructing a signature
+        /// base string per RFC5849.
+        /// </summary>
+        public NameValueCollectionShould()
+        {
+            _collection =
+                new NameValueCollection
+                {
+                    {"b5", "=%3D"},
+                    {"a3", "a"},
+                    {"c@", ""},
+                    {"a2","r b"},
+                    {OAuthConstants.ConsumerKeyParameter, "9djdj82h48djs9d2"},
+                    {OAuthConstants.TokenParameter, "kkk9d7dh3k39sjv7"},
+                    {OAuthConstants.SignatureMethodParameter, OAuthConstants.SignatureMethodHmacSha1},
+                    {OAuthConstants.TimestampParameter, "137131201"},
+                    {OAuthConstants.NonceParameter, "7d8f3e4a"},
+                    {"c2", ""},
+                    {"a3", "2 q"}
+                };
+
+            _expected =
+                "a2=r%20b&a3=2%20q&a3=a&b5=%3D%253D&c%40=&c2=&oauth_consumer_key=9dj"
+                + "dj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1"
+                + "&oauth_timestamp=137131201&oauth_token=kkk9d7dh3k39sjv7";
+        }
+
+        [Fact]
+        // https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
+        // Sort the parameters by name, then value
+        public void ReturnNormalizedStringPerRfc5849()
+        {
+            Assert.Equal(_expected, _collection.ToNormalizedString());
+        }
+
+        [Fact]
+        // https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1
+        // Exclude the OAuth signature or realm in the signature base string
+        public void NotIncludeSignatureOrRealmInNormalizedString()
+        {
+            var collection = new NameValueCollection(_collection)
+            {
+                {OAuthConstants.SignatureParameter, "signature"},
+                {OAuthConstants.RealmParameter, "realm"}
+            };
+            Assert.Equal(_expected, collection.ToNormalizedString());
+        }
+    }
+}


### PR DESCRIPTION
- NameValueCollection.ToNormalizedString() returns expected results when multiple parameters have the same name
- Removed unused NameValueCollection extensions
- New unit tests to make sure NameValueCollectionExtensions are behaving
  
  