### PR TITLE
In HttpResponseExtensions, encode the parameters

### DIFF
--- a/src/LtiLibrary.AspNetCore/Extensions/HttpResponseExtensions.cs
+++ b/src/LtiLibrary.AspNetCore/Extensions/HttpResponseExtensions.cs
@@ -27,7 +27,7 @@ namespace LtiLibrary.AspNetCore.Extensions
             form.AppendFormat("<form method='post' action='{0}' id='form'>", request.Url.AbsoluteUri).AppendLine();
             foreach (var key in request.Parameters.AllKeys)
             {
-                form.AppendFormat("<input type='hidden' name='{0}' value='{1}' />", key, request.Parameters[key])
+                form.AppendFormat("<input type='hidden' name='{0}' value='{1}' />", key, HttpContext.Current.Server.HtmlEncode(request.Parameters[key]))
                     .AppendLine();
             }
             form.AppendLine("</form>");

--- a/src/LtiLibrary.AspNetCore/Extensions/HttpResponseExtensions.cs
+++ b/src/LtiLibrary.AspNetCore/Extensions/HttpResponseExtensions.cs
@@ -27,7 +27,7 @@ namespace LtiLibrary.AspNetCore.Extensions
             form.AppendFormat("<form method='post' action='{0}' id='form'>", request.Url.AbsoluteUri).AppendLine();
             foreach (var key in request.Parameters.AllKeys)
             {
-                form.AppendFormat("<input type='hidden' name='{0}' value='{1}' />", key, HttpContext.Current.Server.HtmlEncode(request.Parameters[key]))
+                form.AppendFormat("<input type='hidden' name='{0}' value='{1}' />", key, System.Net.WebUtility.HtmlEncode(request.Parameters[key]))
                     .AppendLine();
             }
             form.AppendLine("</form>");


### PR DESCRIPTION
The value of a parameter can contain characters that break the HTML form post.
E.g. a single quote in lis_person_name_full = "d'Artagnan", would cause a form post with input value="d".
NB I tested my fix on an older version of the LtiLibrary, so I did not actually compile and test my proposed change - sorry for that.