### PR TITLE
Make AddBodyHashHeaderAttribute compatible with ASP.NET Core 2.1+

### DIFF
--- a/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
+++ b/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
@@ -32,6 +32,9 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http">
+      <Version>2.2.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
References:

[Re-reading ASP.Net Core request bodies with EnableBuffering(](https://devblogs.microsoft.com/aspnet/re-reading-asp-net-core-request-bodies-with-enablebuffering/))

[HTTP: Synchronous IO disabled in all servers](https://docs.microsoft.com/en-us/dotnet/core/compatibility/2.2-3.0#http-synchronous-io-disabled-in-all-servers)

[Add HashAlgorithm.ComputeHashAsync (.NET Core 5.0)](https://github.com/dotnet/corefx/pull/42565)
