### PR TITLE
Address Threading In Outcomes Client + other issues

### DIFF
--- a/src/LtiLibrary.AspNetCore/Common/AddBodyHashHeaderAttribute.cs
+++ b/src/LtiLibrary.AspNetCore/Common/AddBodyHashHeaderAttribute.cs
@@ -45,7 +45,7 @@ namespace LtiLibrary.AspNetCore.Common
                 }
             }
 
-            await next();
+            await next().ConfigureAwait(false);
         }
     }
 }

--- a/src/LtiLibrary.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/src/LtiLibrary.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -23,7 +23,8 @@ namespace LtiLibrary.AspNetCore.Extensions
             // Normal LTI launch with form parameters
             if (request.HasFormContentType)
             {
-                var messageType = request.Form[LtiConstants.LtiMessageTypeParameter][0] ?? string.Empty;
+                var messageTypeArray = request.Form[LtiConstants.LtiMessageTypeParameter];
+                var messageType = messageTypeArray.Count > 0 ? messageTypeArray[0] : string.Empty;
                 return request.Method.Equals("POST")
                        && (
                            messageType.Equals(LtiConstants.BasicLaunchLtiMessageType,

--- a/src/LtiLibrary.AspNetCore/Outcomes/v1/ImsxXmlMediaTypeModelBinder.cs
+++ b/src/LtiLibrary.AspNetCore/Outcomes/v1/ImsxXmlMediaTypeModelBinder.cs
@@ -17,7 +17,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
             null, null, new XmlRootAttribute("imsx_POXEnvelopeRequest"),
             "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0");
 
-        public async Task BindModelAsync(ModelBindingContext bindingContext)
+        public Task BindModelAsync(ModelBindingContext bindingContext)
         {
             if (bindingContext == null) throw new ArgumentNullException(nameof(bindingContext));
 
@@ -42,7 +42,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
             }
 
             // To avoid warning that there are no await call in this async method
-            await Task.Yield();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/LtiLibrary.AspNetCore/Outcomes/v1/ImsxXmlMediaTypeOutputFormatter.cs
+++ b/src/LtiLibrary.AspNetCore/Outcomes/v1/ImsxXmlMediaTypeOutputFormatter.cs
@@ -37,7 +37,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
             using (var writer = context.WriterFactory(response.Body, Encoding.UTF8))
             {
                 ImsxResponseSerializer.Serialize(writer, context.Object);
-                await writer.FlushAsync();
+                await writer.FlushAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/LtiLibrary.AspNetCore/Outcomes/v1/OutcomesControllerBase.cs
+++ b/src/LtiLibrary.AspNetCore/Outcomes/v1/OutcomesControllerBase.cs
@@ -69,22 +69,19 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
                     {
                         return StatusCode(StatusCodes.Status404NotFound);
                     }
-                    return await HandleDeleteResultRequest(requestHeader, requestBody)
-                        .ConfigureAwait(false);
+                    return await HandleDeleteResultRequest(requestHeader, requestBody).ConfigureAwait(false);
                 case readResultRequest _:
                     if (OnReadResultAsync == null)
                     {
                         return StatusCode(StatusCodes.Status404NotFound);
                     }
-                    return await HandleReadResultRequest(requestHeader, requestBody)
-                        .ConfigureAwait(false);
+                    return await HandleReadResultRequest(requestHeader, requestBody).ConfigureAwait(false);
                 case replaceResultRequest _:
                     if (OnReplaceResultAsync == null)
                     {
                         return StatusCode(StatusCodes.Status404NotFound);
                     }
-                    return await HandleReplaceResultRequest(requestHeader, requestBody)
-                        .ConfigureAwait(false);
+                    return await HandleReplaceResultRequest(requestHeader, requestBody).ConfigureAwait(false);
             }
             return BadRequest("Request type not supported.");
         }
@@ -189,7 +186,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
             try
             {
                 var request = new DeleteResultRequest(result.SourcedId);
-                var response = await OnDeleteResultAsync(request);
+                var response = await OnDeleteResultAsync(request).ConfigureAwait(false);
 
                 if (response.StatusCode != StatusCodes.Status200OK)
                 {
@@ -214,7 +211,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
             try
             {
                 var request = new ReadResultRequest(readRequest.resultRecord.sourcedGUID.sourcedId);
-                var response = await OnReadResultAsync(request);
+                var response = await OnReadResultAsync(request).ConfigureAwait(false);
 
                 if (response.StatusCode != StatusCodes.Status200OK)
                 {
@@ -285,7 +282,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v1
             try
             {
                 var request = new ReplaceResultRequest(result);
-                var response = await OnReplaceResultAsync(request);
+                var response = await OnReplaceResultAsync(request).ConfigureAwait(false);
 
                 if (response.StatusCode != StatusCodes.Status200OK)
                 {

--- a/src/LtiLibrary.AspNetCore/Outcomes/v2/LineItemModelBinder.cs
+++ b/src/LtiLibrary.AspNetCore/Outcomes/v2/LineItemModelBinder.cs
@@ -23,7 +23,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v2
                 {
                     using (var reader = new StreamReader(bindingContext.HttpContext.Request.Body))
                     {
-                        var body = await reader.ReadToEndAsync();
+                        var body = await reader.ReadToEndAsync().ConfigureAwait(false);
                         var model = JsonConvert.DeserializeObject<LineItem>(body);
                         bindingContext.Result = ModelBindingResult.Success(model);
                     }

--- a/src/LtiLibrary.AspNetCore/Outcomes/v2/LisResultModelBinder.cs
+++ b/src/LtiLibrary.AspNetCore/Outcomes/v2/LisResultModelBinder.cs
@@ -23,7 +23,7 @@ namespace LtiLibrary.AspNetCore.Outcomes.v2
                 {
                     using (var reader = new StreamReader(bindingContext.HttpContext.Request.Body))
                     {
-                        var body = await reader.ReadToEndAsync();
+                        var body = await reader.ReadToEndAsync().ConfigureAwait(false);
                         var model = JsonConvert.DeserializeObject<Result>(body);
                         bindingContext.Result = ModelBindingResult.Success(model);
                     }

--- a/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
@@ -128,7 +128,7 @@ namespace LtiLibrary.NetCore.Clients
             {
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, serviceUrl);
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
-                await SecuredClient.SignRequest(request, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, request, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse<MembershipContainerPage>();
                 try

--- a/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -37,7 +37,7 @@ namespace LtiLibrary.NetCore.Clients
             var filteredServiceUrl = GetFilteredServiceUrl(serviceUrl, null, rlid, role);
             var pageResponse = await GetFilteredMembershipPageAsync
                 (
-                    client, filteredServiceUrl, consumerKey, consumerSecret, 
+                    client, filteredServiceUrl, consumerKey, consumerSecret,
                     LtiConstants.LisMembershipContainerMediaType, signatureMethod,
                     deserializationErrorHandler
                 ).ConfigureAwait(false);
@@ -70,13 +70,13 @@ namespace LtiLibrary.NetCore.Clients
                     return result;
                 }
                 pageId = pageResponse.Response.Id;
-                
+
                 // Add the memberships to the list (the collection cannot be null)
                 if (pageResponse.Response.MembershipContainer?.MembershipSubject?.Membership != null)
                 {
                     result.Response.AddRange(pageResponse.Response.MembershipContainer.MembershipSubject.Membership);
                 }
-                
+
                 // Repeat until there is no NextPage
                 if (string.IsNullOrWhiteSpace(pageResponse.Response.NextPage)) break;
 
@@ -84,7 +84,7 @@ namespace LtiLibrary.NetCore.Clients
                 filteredServiceUrl = GetFilteredServiceUrl(pageResponse.Response.NextPage, null, rlid, role);
                 pageResponse = await GetFilteredMembershipPageAsync
                     (
-                        client, filteredServiceUrl, consumerKey, consumerSecret, 
+                        client, filteredServiceUrl, consumerKey, consumerSecret,
                         LtiConstants.LisMembershipContainerMediaType, signatureMethod,
                         deserializationErrorHandler
                     ).ConfigureAwait(false);
@@ -126,16 +126,14 @@ namespace LtiLibrary.NetCore.Clients
         {
             try
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
-
-                await SecuredClient.SignRequest(client, HttpMethod.Get, serviceUrl, new StringContent(string.Empty), consumerKey,
-                    consumerSecret, signatureMethod);
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, serviceUrl);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
+                await SecuredClient.SignRequest(request, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse<MembershipContainerPage>();
                 try
                 {
-                    using (var response = await client.GetAsync(serviceUrl).ConfigureAwait(false))
+                    using (var response = await client.SendAsync(request).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.StatusCode == HttpStatusCode.OK)

--- a/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/MembershipClient.cs
@@ -128,7 +128,7 @@ namespace LtiLibrary.NetCore.Clients
             {
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, serviceUrl);
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
-                await SecuredClient.SignRequest(client, request, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, request, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
 
                 var outcomeResponse = new ClientResponse<MembershipContainerPage>();
                 try
@@ -138,14 +138,11 @@ namespace LtiLibrary.NetCore.Clients
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.StatusCode == HttpStatusCode.OK)
                         {
-                            outcomeResponse.Response = await response.DeserializeJsonObjectAsync<MembershipContainerPage>(deserializationErrorHandler)
-                                .ConfigureAwait(false);
+                            outcomeResponse.Response = await response.DeserializeJsonObjectAsync<MembershipContainerPage>(deserializationErrorHandler).ConfigureAwait(false);
                         }
 #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync()
-                            .ConfigureAwait(false);
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync()
-                            .ConfigureAwait(false);
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync().ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
 #endif
                     }
                 }

--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -33,8 +33,8 @@ namespace LtiLibrary.NetCore.Clients
             ImsxRequestSerializer = new XmlSerializer(typeof(imsx_POXEnvelopeType),
                 null, null, new XmlRootAttribute("imsx_POXEnvelopeRequest"),
                     "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0");
-            ImsxResponseSerializer = new XmlSerializer(typeof(imsx_POXEnvelopeType), 
-                null, null, new XmlRootAttribute("imsx_POXEnvelopeResponse"), 
+            ImsxResponseSerializer = new XmlSerializer(typeof(imsx_POXEnvelopeType),
+                null, null, new XmlRootAttribute("imsx_POXEnvelopeResponse"),
                     "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0");
         }
 
@@ -48,42 +48,43 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="sourcedId">The LisResultSourcedId to be deleted.</param>
         /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
-        public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+        public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
             string sourcedId, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             try
             {
                 var imsxEnvelope = new imsx_POXEnvelopeType
                 {
-                    imsx_POXHeader = new imsx_POXHeaderType {Item = new imsx_RequestHeaderInfoType()},
-                    imsx_POXBody = new imsx_POXBodyType {Item = new deleteResultRequest()}
+                    imsx_POXHeader = new imsx_POXHeaderType { Item = new imsx_RequestHeaderInfoType() },
+                    imsx_POXBody = new imsx_POXBodyType { Item = new deleteResultRequest() }
                 };
 
-                var imsxHeader = (imsx_RequestHeaderInfoType) imsxEnvelope.imsx_POXHeader.Item;
+                var imsxHeader = (imsx_RequestHeaderInfoType)imsxEnvelope.imsx_POXHeader.Item;
                 imsxHeader.imsx_version = imsx_GWSVersionValueType.V10;
                 imsxHeader.imsx_messageIdentifier = Guid.NewGuid().ToString();
 
-                var imsxBody = (deleteResultRequest) imsxEnvelope.imsx_POXBody.Item;
+                var imsxBody = (deleteResultRequest)imsxEnvelope.imsx_POXBody.Item;
                 imsxBody.resultRecord = new ResultRecordType
                 {
-                    sourcedGUID = new SourcedGUIDType {sourcedId = sourcedId}
+                    sourcedGUID = new SourcedGUIDType { sourcedId = sourcedId }
                 };
 
                 var outcomeResponse = new ClientResponse();
                 try
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope).ConfigureAwait(false);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(
-                        client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod)
+                    HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+                    {
+                        Content = xmlContent
+                    };
+                    webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
+                    await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod)
                         .ConfigureAwait(false);
 
                     // Post the request and check the response
-                    using (var response = await client.PostAsync(serviceUrl, xmlContent).ConfigureAwait(false))
+                    using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.IsSuccessStatusCode)
@@ -138,7 +139,7 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="lisResultSourcedId">The LisResult to read.</param>
         /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
-        public static async Task<ClientResponse<Result>> ReadResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+        public static async Task<ClientResponse<Result>> ReadResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
             string lisResultSourcedId, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             try
@@ -162,18 +163,19 @@ namespace LtiLibrary.NetCore.Clients
                 var outcomeResponse = new ClientResponse<Result>();
                 try
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope).ConfigureAwait(false);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest
-                        (client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod)
+                    HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+                    {
+                        Content = xmlContent
+                    };
+                    webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
+                    await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod)
                         .ConfigureAwait(false);
 
                     // Post the request and check the response
-                    using (var response = await client.PostAsync(serviceUrl, xmlContent).ConfigureAwait(false))
+                    using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.IsSuccessStatusCode)
@@ -196,11 +198,11 @@ namespace LtiLibrary.NetCore.Clients
                                     // a little bit of misbehaving. If the TP does not include a language, "en" will
                                     // be used. If the TP does include a language (even a non-en language), it will
                                     // be used.
-                                    var cultureInfo = new CultureInfo(imsxResponseBody.result.resultScore.language??LtiConstants.ScoreLanguage);
-                                    outcomeResponse.Response = double.TryParse(imsxResponseBody.result.resultScore.textString, NumberStyles.Number, cultureInfo, out var score) 
-                                        ? new Result { Score = score, SourcedId = lisResultSourcedId } 
+                                    var cultureInfo = new CultureInfo(imsxResponseBody.result.resultScore.language ?? LtiConstants.ScoreLanguage);
+                                    outcomeResponse.Response = double.TryParse(imsxResponseBody.result.resultScore.textString, NumberStyles.Number, cultureInfo, out var score)
+                                        ? new Result { Score = score, SourcedId = lisResultSourcedId }
                                         : new Result { Score = null, SourcedId = lisResultSourcedId };
-                                    
+
                                     // Optional Canvas-style submission details
                                     var resultData = imsxResponseBody.result.ResultData;
                                     outcomeResponse.Response.LtiLaunchUrl = resultData?.LtiLaunchUrl;
@@ -258,25 +260,25 @@ namespace LtiLibrary.NetCore.Clients
         /// <param name="ltiLaunchUrl">Optional LTI launch URL data</param>
         /// <param name="signatureMethod">The signatureMethod. Defaults to <see cref="SignatureMethod.HmacSha1"/></param>
         /// <returns>A <see cref="ClientResponse"/>.</returns>
-        public static async Task<ClientResponse> ReplaceResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
+        public static async Task<ClientResponse> ReplaceResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret,
             string lisResultSourcedId, double? score, string text = null, string url = null, string ltiLaunchUrl = null, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
             try
             {
                 var imsxEnvelope = new imsx_POXEnvelopeType
                 {
-                    imsx_POXHeader = new imsx_POXHeaderType {Item = new imsx_RequestHeaderInfoType()},
-                    imsx_POXBody = new imsx_POXBodyType {Item = new replaceResultRequest()}
+                    imsx_POXHeader = new imsx_POXHeaderType { Item = new imsx_RequestHeaderInfoType() },
+                    imsx_POXBody = new imsx_POXBodyType { Item = new replaceResultRequest() }
                 };
 
-                var imsxHeader = (imsx_RequestHeaderInfoType) imsxEnvelope.imsx_POXHeader.Item;
+                var imsxHeader = (imsx_RequestHeaderInfoType)imsxEnvelope.imsx_POXHeader.Item;
                 imsxHeader.imsx_version = imsx_GWSVersionValueType.V10;
                 imsxHeader.imsx_messageIdentifier = Guid.NewGuid().ToString();
 
-                var imsxBody = (replaceResultRequest) imsxEnvelope.imsx_POXBody.Item;
+                var imsxBody = (replaceResultRequest)imsxEnvelope.imsx_POXBody.Item;
                 imsxBody.resultRecord = new ResultRecordType
                 {
-                    sourcedGUID = new SourcedGUIDType {sourcedId = lisResultSourcedId},
+                    sourcedGUID = new SourcedGUIDType { sourcedId = lisResultSourcedId },
                     result = new ResultType
                     {
                         resultScore = new TextType
@@ -302,17 +304,19 @@ namespace LtiLibrary.NetCore.Clients
                 var outcomeResponse = new ClientResponse();
                 try
                 {
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-
                     // Create a UTF8 encoding of the request
                     var xml = await GetXmlAsync(imsxEnvelope).ConfigureAwait(false);
                     var xmlContent = new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType);
-                    await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, xmlContent, consumerKey, consumerSecret, signatureMethod)
+                    HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+                    {
+                        Content = xmlContent
+                    };
+                    webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
+                    await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod)
                         .ConfigureAwait(false);
 
                     // Post the request and check the response
-                    using (var response = await client.PostAsync(serviceUrl, xmlContent).ConfigureAwait(false))
+                    using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.IsSuccessStatusCode)

--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -80,7 +80,7 @@ namespace LtiLibrary.NetCore.Clients
                         Content = xmlContent
                     };
                     webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod)
+                    await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod)
                         .ConfigureAwait(false);
 
                     // Post the request and check the response
@@ -171,7 +171,7 @@ namespace LtiLibrary.NetCore.Clients
                         Content = xmlContent
                     };
                     webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod)
+                    await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod)
                         .ConfigureAwait(false);
 
                     // Post the request and check the response
@@ -312,7 +312,7 @@ namespace LtiLibrary.NetCore.Clients
                         Content = xmlContent
                     };
                     webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod)
+                    await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod)
                         .ConfigureAwait(false);
 
                     // Post the request and check the response

--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -143,8 +143,8 @@ namespace LtiLibrary.NetCore.Clients
             {
                 var imsxEnvelope = new imsx_POXEnvelopeType
                 {
-                    imsx_POXHeader = new imsx_POXHeaderType { Item = new imsx_RequestHeaderInfoType() },
-                    imsx_POXBody = new imsx_POXBodyType { Item = new readResultRequest() }
+                    imsx_POXHeader = new imsx_POXHeaderType {Item = new imsx_RequestHeaderInfoType()},
+                    imsx_POXBody = new imsx_POXBodyType {Item = new readResultRequest()}
                 };
 
                 var imsxHeader = (imsx_RequestHeaderInfoType)imsxEnvelope.imsx_POXHeader.Item;
@@ -323,6 +323,8 @@ namespace LtiLibrary.NetCore.Clients
                             outcomeResponse.StatusCode = imsxResponseStatus == imsx_CodeMajorType.success
                                 ? HttpStatusCode.OK
                                 : HttpStatusCode.BadRequest;
+                            outcomeResponse.Severity = imsxResponseHeader.imsx_statusInfo.imsx_severity;
+                            outcomeResponse.MinorCode = imsxResponseHeader.imsx_statusInfo.imsx_codeMinor;
                         }
 #if DEBUG
                         outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync

--- a/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes1Client.cs
@@ -80,8 +80,7 @@ namespace LtiLibrary.NetCore.Clients
                         Content = xmlContent
                     };
                     webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod)
-                        .ConfigureAwait(false);
+                    await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
 
                     // Post the request and check the response
                     using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
@@ -100,11 +99,9 @@ namespace LtiLibrary.NetCore.Clients
                         }
 #if DEBUG
                         outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync
-                            (new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType))
-                            .ConfigureAwait(false);
+                            (new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType)).ConfigureAwait(false);
 #endif
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync()
-                            .ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
                     }
                 }
                 catch (HttpRequestException ex)
@@ -171,8 +168,7 @@ namespace LtiLibrary.NetCore.Clients
                         Content = xmlContent
                     };
                     webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.ImsxOutcomeMediaType));
-                    await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod)
-                        .ConfigureAwait(false);
+                    await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
 
                     // Post the request and check the response
                     using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
@@ -217,11 +213,9 @@ namespace LtiLibrary.NetCore.Clients
                         }
 #if DEBUG
                         outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync
-                            (new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType))
-                            .ConfigureAwait(false);
+                            (new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType)).ConfigureAwait(false);
 #endif
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync()
-                            .ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
                     }
                 }
                 catch (HttpRequestException ex)
@@ -332,11 +326,9 @@ namespace LtiLibrary.NetCore.Clients
                         }
 #if DEBUG
                         outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync
-                            (new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType))
-                            .ConfigureAwait(false);
+                            (new StringContent(xml, Encoding.UTF8, LtiConstants.ImsxOutcomeMediaType)).ConfigureAwait(false);
 #endif
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync()
-                            .ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
                     }
                 }
                 catch (HttpRequestException ex)
@@ -379,7 +371,7 @@ namespace LtiLibrary.NetCore.Clients
                     }))
                 {
                     ImsxRequestSerializer.Serialize(writer, imsxEnvelope);
-                    await writer.FlushAsync();
+                    await writer.FlushAsync().ConfigureAwait(false);
                 }
                 return Encoding.UTF8.GetString(ms.ToArray());
             }

--- a/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -302,7 +302,8 @@ namespace LtiLibrary.NetCore.Clients
         {
             try
             {
-                await SecuredClient.SignRequest(client, HttpMethod.Delete, serviceUrl, new StringContent(string.Empty), consumerKey, consumerSecret, signatureMethod);
+                HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Delete, serviceUrl);
+                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse();
                 try
@@ -310,7 +311,7 @@ namespace LtiLibrary.NetCore.Clients
                     // HttpClient does not send content in a DELETE request. So there is no Content-Type
                     // header. Therefore, all representations of the resource will be deleted.
                     // See https://www.imsglobal.org/lti/model/uml/purl.imsglobal.org/vocab/lis/v2/outcomes/LineItem/service.html#DELETE
-                    using (var response = await client.DeleteAsync(serviceUrl))
+                    using (var response = await client.SendAsync(webRequest))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
 #if DEBUG
@@ -348,15 +349,14 @@ namespace LtiLibrary.NetCore.Clients
         {
             try
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
-
-                await SecuredClient.SignRequest(client, HttpMethod.Get, serviceUrl, new StringContent(string.Empty), consumerKey, consumerSecret, signatureMethod);
+                HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Get, serviceUrl);
+                webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
+                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
                 
                 var outcomeResponse = new ClientResponse<T>();
                 try
                 {
-                    using (var response = await client.GetAsync(serviceUrl))
+                    using (var response = await client.SendAsync(webRequest))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.StatusCode == HttpStatusCode.OK)
@@ -428,14 +428,16 @@ namespace LtiLibrary.NetCore.Clients
         {
             try
             {
-                var httpContent = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType);
-
-                await SecuredClient.SignRequest(client, HttpMethod.Post, serviceUrl, httpContent, consumerKey, consumerSecret, signatureMethod);
+                HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+                {
+                    Content = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType)
+                };
+                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse<T>();
                 try
                 {
-                    using (var response = await client.PostAsync(serviceUrl, httpContent))
+                    using (var response = await client.SendAsync(webRequest))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.StatusCode == HttpStatusCode.Created)
@@ -476,14 +478,16 @@ namespace LtiLibrary.NetCore.Clients
         {
             try
             {
-                var httpContent = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType);
-
-                await SecuredClient.SignRequest(client, HttpMethod.Put, serviceUrl, httpContent, consumerKey, consumerSecret, signatureMethod);
+                HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Put, serviceUrl)
+                {
+                    Content = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType)
+                };
+                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse();
                 try
                 {
-                    using (var response = await client.PutAsync(serviceUrl, httpContent))
+                    using (var response = await client.SendAsync(webRequest))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
 #if DEBUG

--- a/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
@@ -303,7 +303,7 @@ namespace LtiLibrary.NetCore.Clients
             try
             {
                 HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Delete, serviceUrl);
-                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse();
                 try
@@ -351,7 +351,7 @@ namespace LtiLibrary.NetCore.Clients
             {
                 HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Get, serviceUrl);
                 webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
-                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
                 
                 var outcomeResponse = new ClientResponse<T>();
                 try
@@ -432,7 +432,7 @@ namespace LtiLibrary.NetCore.Clients
                 {
                     Content = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType)
                 };
-                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse<T>();
                 try
@@ -482,7 +482,7 @@ namespace LtiLibrary.NetCore.Clients
                 {
                     Content = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType)
                 };
-                await SecuredClient.SignRequest(webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
 
                 var outcomeResponse = new ClientResponse();
                 try

--- a/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
+++ b/src/LtiLibrary.NetCore/Clients/Outcomes2Client.cs
@@ -164,8 +164,7 @@ namespace LtiLibrary.NetCore.Clients
         public static async Task<ClientResponse> PutLineItemAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, 
             LineItem lineItem, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
-            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType, signatureMethod)
-                .ConfigureAwait(false);
+            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, lineItem, LtiConstants.LisLineItemMediaType, signatureMethod).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -201,8 +200,7 @@ namespace LtiLibrary.NetCore.Clients
         public static async Task<ClientResponse> DeleteResultAsync(HttpClient client, string serviceUrl, string consumerKey,
             string consumerSecret, SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
-            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod)
-                .ConfigureAwait(false);
+            return await DeleteOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -289,8 +287,7 @@ namespace LtiLibrary.NetCore.Clients
         public static async Task<ClientResponse> PutResultAsync(HttpClient client, string serviceUrl, string consumerKey, string consumerSecret, Result result,
             SignatureMethod signatureMethod = SignatureMethod.HmacSha1)
         {
-            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType, signatureMethod)
-                .ConfigureAwait(false);
+            return await PutOutcomeAsync(client, serviceUrl, consumerKey, consumerSecret, result, LtiConstants.LisResultMediaType, signatureMethod).ConfigureAwait(false);
         }
 
         #endregion
@@ -303,7 +300,7 @@ namespace LtiLibrary.NetCore.Clients
             try
             {
                 HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Delete, serviceUrl);
-                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
 
                 var outcomeResponse = new ClientResponse();
                 try
@@ -311,12 +308,12 @@ namespace LtiLibrary.NetCore.Clients
                     // HttpClient does not send content in a DELETE request. So there is no Content-Type
                     // header. Therefore, all representations of the resource will be deleted.
                     // See https://www.imsglobal.org/lti/model/uml/purl.imsglobal.org/vocab/lis/v2/outcomes/LineItem/service.html#DELETE
-                    using (var response = await client.SendAsync(webRequest))
+                    using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
 #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync();
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync();
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync().ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
 #endif
                     }
                 }
@@ -351,21 +348,21 @@ namespace LtiLibrary.NetCore.Clients
             {
                 HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Get, serviceUrl);
                 webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(contentType));
-                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
                 
                 var outcomeResponse = new ClientResponse<T>();
                 try
                 {
-                    using (var response = await client.SendAsync(webRequest))
+                    using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.StatusCode == HttpStatusCode.OK)
                         {
-                            outcomeResponse.Response = await response.DeserializeJsonObjectAsync<T>(deserializationErrorHandler);
+                            outcomeResponse.Response = await response.DeserializeJsonObjectAsync<T>(deserializationErrorHandler).ConfigureAwait(false);
                         }
 #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync();
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync();
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync().ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
 #endif
                     }
                 }
@@ -432,21 +429,21 @@ namespace LtiLibrary.NetCore.Clients
                 {
                     Content = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType)
                 };
-                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
 
                 var outcomeResponse = new ClientResponse<T>();
                 try
                 {
-                    using (var response = await client.SendAsync(webRequest))
+                    using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
                         if (response.StatusCode == HttpStatusCode.Created)
                         {
-                            outcomeResponse.Response = await response.DeserializeJsonObjectAsync<T>(deserializationErrorHandler);
+                            outcomeResponse.Response = await response.DeserializeJsonObjectAsync<T>(deserializationErrorHandler).ConfigureAwait(false);
                         }
 #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync();
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync();
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync().ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
 #endif
                     }
                 }
@@ -482,17 +479,17 @@ namespace LtiLibrary.NetCore.Clients
                 {
                     Content = new StringContent(content.ToJsonLdString(), Encoding.UTF8, contentType)
                 };
-                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod);
+                await SecuredClient.SignRequest(client, webRequest, consumerKey, consumerSecret, signatureMethod).ConfigureAwait(false);
 
                 var outcomeResponse = new ClientResponse();
                 try
                 {
-                    using (var response = await client.SendAsync(webRequest))
+                    using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
                     {
                         outcomeResponse.StatusCode = response.StatusCode;
 #if DEBUG
-                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync();
-                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync();
+                        outcomeResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync().ConfigureAwait(false);
+                        outcomeResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
 #endif
                     }
                 }

--- a/src/LtiLibrary.NetCore/Clients/SecuredClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/SecuredClient.cs
@@ -86,7 +86,7 @@ namespace LtiLibrary.NetCore.Clients
             // Create an Authorization header using the body hash
             using (sha)
             {
-                var hash = sha.ComputeHash(await (request.Content ?? new StringContent(string.Empty)).ReadAsByteArrayAsync());
+                var hash = sha.ComputeHash(await (request.Content ?? new StringContent(string.Empty)).ReadAsByteArrayAsync().ConfigureAwait(false));
                 authorizationHeader = ltiRequest.GenerateAuthorizationHeader(hash, consumerSecret);
             }
 

--- a/src/LtiLibrary.NetCore/Clients/ToolConsumerProfileClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/ToolConsumerProfileClient.cs
@@ -32,10 +32,8 @@ namespace LtiLibrary.NetCore.Clients
                         await response.Content.ReadJsonAsObjectAsync<ToolConsumerProfile>().ConfigureAwait(false);
                 }
 #if DEBUG
-                profileResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync()
-                    .ConfigureAwait(false);
-                profileResponse.HttpResponse = await response.ToFormattedResponseStringAsync()
-                    .ConfigureAwait(false);
+                profileResponse.HttpRequest = await response.RequestMessage.ToFormattedRequestStringAsync().ConfigureAwait(false);
+                profileResponse.HttpResponse = await response.ToFormattedResponseStringAsync().ConfigureAwait(false);
 #endif
             }
             return profileResponse;

--- a/src/LtiLibrary.NetCore/Clients/ToolConsumerProfileClient.cs
+++ b/src/LtiLibrary.NetCore/Clients/ToolConsumerProfileClient.cs
@@ -20,11 +20,10 @@ namespace LtiLibrary.NetCore.Clients
         /// <returns>A <see cref="ClientResponse"/> with the <see cref="ToolConsumerProfile"/> successful.</returns>
         public static async Task<ClientResponse<ToolConsumerProfile>> GetToolConsumerProfileAsync(HttpClient client, string serviceUrl)
         {
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.LtiToolConsumerProfileMediaType));
-
             var profileResponse = new ClientResponse<ToolConsumerProfile>();
-            using (var response = await client.GetAsync(serviceUrl).ConfigureAwait(false))
+            HttpRequestMessage webRequest = new HttpRequestMessage(HttpMethod.Get, serviceUrl);
+            webRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(LtiConstants.LtiToolConsumerProfileMediaType));
+            using (var response = await client.SendAsync(webRequest).ConfigureAwait(false))
             {
                 profileResponse.StatusCode = response.StatusCode;
                 if (response.IsSuccessStatusCode)

--- a/src/LtiLibrary.NetCore/Common/ClientResponse.cs
+++ b/src/LtiLibrary.NetCore/Common/ClientResponse.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LtiLibrary.NetCore.Lti.v1;
+using System;
 using System.Net;
 
 namespace LtiLibrary.NetCore.Common
@@ -27,6 +28,8 @@ namespace LtiLibrary.NetCore.Common
         /// String representation of the HttpWebResponse similar to Fiddler's.
         /// </summary>
         public string HttpResponse { get; set; }
+        public imsx_SeverityType Severity { get; internal set; }
+        public imsx_CodeMinorFieldType[] MinorCode { get; internal set; }
     }
 
     /// <summary>

--- a/src/LtiLibrary.NetCore/Lti/v1/LtiRequest.cs
+++ b/src/LtiLibrary.NetCore/Lti/v1/LtiRequest.cs
@@ -2229,12 +2229,6 @@ namespace LtiLibrary.NetCore.Lti.v1
                 throw new ArgumentException($"{nameof(value)} cannot be null.");
             }
 
-            // Trim any whitespace that surrounds the name
-            name = name.Trim();
-
-            // Trim any whitespace that surrounds the value
-            value = value.Trim();
-
             // At this point the value may contain custom substitution
             // variables. They will be substituted immediately before launch.
             InternalParameters.Add(name, value);

--- a/src/LtiLibrary.NetCore/OAuth/OAuthRequest.cs
+++ b/src/LtiLibrary.NetCore/OAuth/OAuthRequest.cs
@@ -298,7 +298,7 @@ namespace LtiLibrary.NetCore.OAuth
         /// <param name="parametersIn">The collection of parameters to sign</param>
         /// <param name="consumerSecret">The OAuth consumer secret used to generate the signature</param>
         /// <returns>A base64 string of the hash value</returns>
-        private static string GenerateSignature(string httpMethod, Uri url, NameValueCollection parametersIn, string consumerSecret)
+        public static string GenerateSignature(string httpMethod, Uri url, NameValueCollection parametersIn, string consumerSecret)
         {
             // Work with a copy of the parameters so the caller's data is not changed
             var parameters = new NameValueCollection(parametersIn);

--- a/test/LtiLibrary.AspNetCore.Tests/Membership/MembershipControllerShould.cs
+++ b/test/LtiLibrary.AspNetCore.Tests/Membership/MembershipControllerShould.cs
@@ -84,6 +84,42 @@ namespace LtiLibrary.AspNetCore.Tests.Membership
             Assert.Equal(clientResponse.Response[0].Role[0], ContextRole.Instructor);
         }
 
+         [Fact]
+         public async Task ReturnsInstructors_WhenRoleFilterIsInstructorWithNoBaseAddress()
+         {
+            // Given a working LTI Membership Service endpoint
+            // When I call GetMembershipAsync with the Learner role filter
+            var client = _server.CreateClient();
+            client.BaseAddress = null;
+            var clientResponse = await MembershipClient.GetMembershipAsync(client, "http://localhost/ims/membership/context/context-1", Key, Secret, role: ContextRole.Instructor);
+            // Then I get an OK response
+            Assert.Equal(HttpStatusCode.OK, clientResponse.StatusCode);
+            // And the response is not null
+            Assert.NotNull(clientResponse.Response);
+            // And there is exactly one membership
+            Assert.Equal(1, clientResponse.Response.Count);
+            // And the role is Instructor
+            Assert.Equal(clientResponse.Response[0].Role[0], ContextRole.Instructor);
+         }
+
+         [Fact]
+         public async Task ReturnsInstructors_WhenRoleFilterIsInstructorWithExtendedBaseAddress()
+         {
+            // Given a working LTI Membership Service endpoint
+            // When I call GetMembershipAsync with the Learner role filter
+            var client = _server.CreateClient();
+            client.BaseAddress = new Uri("http://localhost/ims/");
+            var clientResponse = await MembershipClient.GetMembershipAsync(client, "membership/context/context-1", Key, Secret, role: ContextRole.Instructor);
+            // Then I get an OK response
+            Assert.Equal(HttpStatusCode.OK, clientResponse.StatusCode);
+            // And the response is not null
+            Assert.NotNull(clientResponse.Response);
+            // And there is exactly one membership
+            Assert.Equal(1, clientResponse.Response.Count);
+            // And the role is Instructor
+            Assert.Equal(clientResponse.Response[0].Role[0], ContextRole.Instructor);
+         }
+
         [Fact]
         public async Task ReturnsLearners_WhenRoleFilterIsLearner()
         {


### PR DESCRIPTION
The use of HttpClient in several of this libraries `Client` objects was unsafe.  Modifying the `DefaultHeaders` on a `HttpClient` is unsafe behavior, and since the client object is accepted as a parameter (in accord with recommendations on client reuse), this underlying collection should not be modified.

Switched to using `HttpRequestMessage` off of the client objects, where these headers can be safely modified.

In addition:
 - Standardized use of ConfigureAwait(false) throughout the library (deadlock risk if this is used inconsistently)
 - Restored static access to a standardized signature calculation method
 - Returned more details of the outcomes response for effective logging and problem diagnosis
 - Fixed a bug where the library assumed that any form-type request was an LTI request, and would get `IndexOutOfBounds` if it wasn't
 - `LtiRequest.AddParameter` was trimming request parameters.  This is inconsistent with signature calculation of at least 1 major LMS (Blackboard), so I removed these trims.

Fixed #115