### PR TITLE
Updating ContextRole parser to allow parsing inputs in any valid form

### DIFF
--- a/test/LtiLibrary.NetCore.Tests/JsonLdObjectTests.cs
+++ b/test/LtiLibrary.NetCore.Tests/JsonLdObjectTests.cs
@@ -75,7 +75,22 @@ namespace LtiLibrary.NetCore.Tests
         [Fact]
         private void ContextRolesAreConvertedFromJsonLdObjects()
         {
-            var contextRole = JsonConvert.DeserializeObject<RoleTestObject>("{ roles: [\"lism:Instructor\"] }");
+            var expectedContextRoles = new ContextRole[]
+            {
+                ContextRole.Instructor,
+                ContextRole.Administrator,
+                ContextRole.Learner,
+                ContextRole.ContentDeveloper
+            };
+
+            var inputContextRoles = "{ roles: [ " +
+                "\"lism:Instructor\", " +
+                "\"http://purl.imsglobal.org/vocab/lis/v2/person#Administrator\", " +
+                "\"Learner\", " +
+                "\"urn:lti:role:ims/lis/ContentDeveloper/ContentExpert\"" +
+            "]}";
+            var actualContextRoles = JsonConvert.DeserializeObject<RoleTestObject>(inputContextRoles);
+            Assert.Equal(actualContextRoles.Roles, expectedContextRoles);
         }
     }
 


### PR DESCRIPTION
## Summary
Allow parsing membership handles in any valid form presented to us in json. This should fix the issues we are facing when requesting membership from Moodle, Blackbaud or any other LMS. Valid `ContextRoles` syntax includes:- 
- lism:\<role\>
- \<role\>
- urn:lti:role:ims/lis/\<role\>/\<sub-role\>
- http://purl.imsglobal.org/vocab/lis/v2/mm#<role\>

> Fixes Issue https://github.com/LtiLibrary/LtiLibrary/issues/109