### PR TITLE
Update Microsoft.AstNetCore.Mvc to latest version, 2.0.0 has security vulnerabilities with Crypto Module

### DIFF
--- a/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
+++ b/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
@@ -38,7 +38,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Background
Existing `Microsoft.ASPNetCore.Mvc` version has several security vulnerabilities which impacts using it in other OSS tools. Updating the Nuget package to latest released version i.e. **v2.2.0**.

> Listed vulnerabilities include: -
> * [<span style="color:red">High</span>] https://nvd.nist.gov/vuln/detail/CVE-2018-0764
> * [<span style="color:red">High</span>] https://nvd.nist.gov/vuln/detail/CVE-2018-0765