### PR TITLE
Replaced deprecated HtmlAgilityPack.Netcore with updated HtmlAgilityPack

### DIFF
--- a/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
+++ b/src/LtiLibrary.AspNetCore/LtiLibrary.AspNetCore.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.33" />
     <PackageReference Include="MinVer" Version="2.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -37,7 +37,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2"/>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Replaced deprecated HtmlAgilityPack.Netcore with updated HtmlAgilityPack (as the author of HtmlAgilityPack.Netcore recommends).  Since these cannot be used together this prevented LtiLibrary.AspNetCore from working with many other packages. For more information: [https://github.com/zulfahmi93/HtmlAgilityPack.NetCore](url)