### PR TITLE
Add utf8 encoding to support language specific characters

### DIFF
--- a/src/LtiLibrary.AspNetCore/Extensions/HttpResponseExtensions.cs
+++ b/src/LtiLibrary.AspNetCore/Extensions/HttpResponseExtensions.cs
@@ -22,7 +22,7 @@ namespace LtiLibrary.AspNetCore.Extensions
             request.Signature = request.SubstituteCustomVariablesAndGenerateSignature(consumerSecret);
             var form = new StringBuilder();
             form.AppendLine("<html>");
-            form.AppendLine("<head><title></title></head>");
+            form.AppendLine("<head><title></title><meta charset='utf-8'/></head>");
             form.AppendLine("<body>");
             form.AppendFormat("<form method='post' action='{0}' id='form'>", request.Url.AbsoluteUri).AppendLine();
             foreach (var pair in request.Parameters)

--- a/test/LtiLibrary.AspNetCore.Tests/ReferenceText/basic-lti-launch-request.txt
+++ b/test/LtiLibrary.AspNetCore.Tests/ReferenceText/basic-lti-launch-request.txt
@@ -1,5 +1,5 @@
 ﻿<html>
-<head><title></title></head>
+<head><title></title><meta charset='utf-8'/></head>
 <body>
 <form method='post' action='http://localhost/toolconsumer/launch' id='form'>
 <input type='hidden' name='oauth_callback' value='about:blank' />


### PR DESCRIPTION
If you use extension method WriteLtiRequest and characters like ö or ü in request parameters then OAuth signature check will fail.
Adding utf8 encoding into html with form solves the issue.